### PR TITLE
Make CPU/Stacktag exctraction multithreaded with -Concurrency dd opti…

### DIFF
--- a/ETWAnalyzer/Commands/ExtractCommand.cs
+++ b/ETWAnalyzer/Commands/ExtractCommand.cs
@@ -32,7 +32,7 @@ namespace ETWAnalyzer.Commands
     {
         internal static readonly string HelpString =
          "ETWAnalyzer [-extract [All, Default or Disk File CPU Memory Exception Stacktag ThreadPool PMC Dns] -filedir/-fd inEtlOrZip [-DryRun] [-symServer NtSymbolPath/MS/Google/syngo] [-keepTemp] [-NoOverwrite] [-pThreads dd] [-nThreads dd]" + Environment.NewLine +
-         "            [-LastNDays dd] [-TestsPerRun dd -SkipNTests dd] [-TestRunIndex dd -TestRunCount dd]  " + Environment.NewLine + 
+         "            [-Concurrency dd] [-LastNDays dd] [-TestsPerRun dd -SkipNTests dd] [-TestRunIndex dd -TestRunCount dd]  " + Environment.NewLine + 
          "Retrieve data from ETL files and store extracted data in a serialized format in Json in the output directory \\Extract folder." + Environment.NewLine +
          "The data can the be analyzed by other tools or ETWAnalyzer itself which can also analyze the data for specific patterns or issues." + Environment.NewLine +
          "Extract Options are separated by space" + Environment.NewLine +
@@ -74,7 +74,8 @@ namespace ETWAnalyzer.Commands
          " -LastNDays dd        Only extract files which are not older then dd days. Fractional days are supported." + Environment.NewLine + 
          " -pthreads dd         Percentage of threads to use during extract. Default is 75% of all cores  with a cap at 5 parallel extractions. " + Environment.NewLine + 
          "                      This can already utilize 100% of all cores because some operations are multithreaded like symbol transcoding." + Environment.NewLine +
-         " -nthreads dd         Absolute number of threads/processes used during extract." + Environment.NewLine +
+         " -nthreads dd         Number of extraction processes (one per file) used during extraction." + Environment.NewLine +
+         " -Concurrency dd      Number of threads used in one extraction process to extract data multithreaded." + Environment.NewLine + 
          " -symServer [NtSymbolPath, MS, Google, syngo or your own symbol server]  Load pdbs from remote symbol server which is stored in the ETWAnalyzer.dll/exe.config file." + Environment.NewLine +
          "                      With NtSymbolPath the contents of the environment variable _NT_SYMBOL_PATH are used." + Environment.NewLine +
          "                      When using a custom remote symbol server use this form with a local folder: E.g. SRV*C:\\Symbols*https://msdl.microsoft.com/download/symbols" + Environment.NewLine + 
@@ -130,7 +131,7 @@ namespace ETWAnalyzer.Commands
         internal const string TimeLineArg = "-timeline";
         internal const string ChildArg = "-child";  // Marker argument to prevent by accident to spawn child of child processes. Child processes process a trace single threaded
         internal const string AllCPUArg = "-allcpu";
-
+        internal const string ConcurrencyArg = "-concurrency";
         internal const string DryRunArg = "-dryrun";
 
 
@@ -305,6 +306,11 @@ namespace ETWAnalyzer.Commands
         /// </summary>
         public bool IsDryRun { get; private set; }
 
+        /// <summary>
+        /// -concurrency Defines how many threads are used during CPU and Stacktag Extraction.
+        /// </summary>
+        public int? Concurrency { get; private set; }
+
 
         /// <summary>
         /// Create an extract command with given command line switches
@@ -365,6 +371,14 @@ namespace ETWAnalyzer.Commands
                             throw new InvalidDataException($"{NThreadsArg} {nThreadsStr} is not a valid number for the thread count.");
                         }
                         myNThreads = tmpNThreads;
+                        break;
+                    case ConcurrencyArg: // -concurrency
+                        string nConcurrencyStr = GetNextNonArg(ConcurrencyArg);
+                        if (!int.TryParse(nConcurrencyStr, out int nConcurrency))
+                        {
+                            throw new InvalidDataException($"{NThreadsArg} {nConcurrencyStr} is not a valid number for the concurrency count.");
+                        }
+                        Concurrency = nConcurrency;
                         break;
                     case TimeLineArg:   // -timeline
                         string timelineInterval = GetNextNonArg(TimeLineArg);
@@ -449,7 +463,7 @@ namespace ETWAnalyzer.Commands
             }
 
             ConfigureExtractors(Extractors, myProcessingActionList);
-            SetExtractorFilters(Extractors, ExtractAllCPUData, DisableExceptionFilter, TimelineDataExtractionIntervalS);
+            SetExtractorFilters(Extractors, ExtractAllCPUData, DisableExceptionFilter, TimelineDataExtractionIntervalS, Concurrency);
 
         }
 
@@ -502,13 +516,20 @@ namespace ETWAnalyzer.Commands
             }
         }
 
-        static void SetExtractorFilters(List<ExtractorBase> extractors, bool extractAllCpuData, bool disableExceptionFilter, float? timelineExtractionInterval)
+        static void SetExtractorFilters(List<ExtractorBase> extractors, bool extractAllCpuData, bool disableExceptionFilter, float? timelineExtractionInterval, int ?concurrency)
         {
             var cpu = extractors.OfType<CPUExtractor>().SingleOrDefault();
             if (cpu != null)
             {
                 cpu.ExtractAllCPUData = extractAllCpuData;
+                cpu.Concurrency = concurrency;
                 cpu.TimelineDataExtractionIntervalS = timelineExtractionInterval;
+            }
+
+            var stacktag = extractors.OfType<StackTagExtractor>().SingleOrDefault();
+            if( stacktag != null)
+            {
+                stacktag.Concurrency = concurrency;
             }
 
             var exception = extractors.OfType<ExceptionExtractor>().SingleOrDefault();
@@ -651,6 +672,13 @@ namespace ETWAnalyzer.Commands
             }
 
             string subCommand = GetCommandLineForSingleExtractFile(fileToAnalyze.FileName);
+
+            // when only one file is extracted we by default use up to 75% of all cores to speed up CPU and Stacktag extraction
+            if(myTotalFilesToExtract == 1 && Concurrency == null)
+            {
+                subCommand += $" {ConcurrencyArg} {CalcMaxThreadCount()}";
+            }
+
             var command = new ProcessCommand(ConfigFiles.ETWAnalyzerExe, subCommand);
             try
             {

--- a/ETWAnalyzer/Extractors/CPU/CpuData.cs
+++ b/ETWAnalyzer/Extractors/CPU/CpuData.cs
@@ -4,6 +4,7 @@
 using ETWAnalyzer.TraceProcessorHelpers;
 using Microsoft.Windows.EventTracing;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -61,10 +62,10 @@ namespace ETWAnalyzer.Extractors.CPU
         /// <summary>
         /// Get for each sample the call stack depth from the bottom frame
         /// </summary>
-        public List<ushort> DepthFromBottom
+        public ConcurrentBag<ushort> DepthFromBottom
         {
             get;
-        } = new List<ushort>();
+        } = new ConcurrentBag<ushort>();
 
         /// <summary>
         /// Contains a merged view of overlapping time range.
@@ -102,8 +103,10 @@ namespace ETWAnalyzer.Extractors.CPU
                 ThreadIds.Add(i);
             }
 
-            DepthFromBottom.AddRange(Enumerable.Repeat<ushort>(depthFromBottom, 5));
-
+            for(int i=0;i<5;i++) // first sample gets some headstart to make mean calculation more stable
+            {
+                DepthFromBottom.Add(depthFromBottom);
+            }
         }
     }
 }

--- a/ETWAnalyzer_uTest/Extract/ConvertCommandTests.cs
+++ b/ETWAnalyzer_uTest/Extract/ConvertCommandTests.cs
@@ -33,9 +33,11 @@ namespace ETWAnalyzer_uTest.Extract
             cmd.Parse();
             cmd.Run();
             Assert.Equal(2, files.Count);
-            Assert.Equal(file1, files[0]);
-            Assert.Equal(file2, files[1]);
+            Assert.Contains(file1, files);
+            Assert.Contains(file2, files);
         }
+
+
         [Fact]
         public void Can_Convert_Single_File()
 
@@ -61,6 +63,8 @@ namespace ETWAnalyzer_uTest.Extract
             cmd.Run();
             Assert.Equal(file1, files[0]);
         }
+
+
         [Fact]
         public void No_File()
         {


### PR DESCRIPTION
…on during -Extract CPU or Stacktag

This improves extraction of a single file up to 40% but gets in the way if multiple files are extracted concurrently. The default is that use still 1 as default concurrency value, except if just one file is extracted. Then we use the default from -pthreads which is 75% of all cores.