### PR TITLE
Support Compressed json output files .json7z

### DIFF
--- a/ETWAnalyzer/3rdParty/ReadMeOSS.md
+++ b/ETWAnalyzer/3rdParty/ReadMeOSS.md
@@ -130,6 +130,20 @@ Perfview
    [Win32ErrorCodes.cs](https://github.com/Siemens-Healthineers/ETWAnalyzer/blob/main/ETWAnalyzer/Extract/PInvoke.NET/WinErrorCodes.cs)
 
 
+**Squid-Box.SevenZipSharp.Lite**
+-----
+* version  
+  1.6.2.24
+ * copyrights
+
+ * license terms  
+   https://github.com/squid-box/SevenZipSharp?tab=LGPL-3.0-1-ov-file#readme
+ * source code  
+   https://github.com/squid-box/SevenZipSharp
+ * integration  
+	The publicly available [Squid-Box.SevenZipSharp] package is consumed and hence contained in releases.
+
+
 <!-- References -->
 [ColorConsole]:                                             <../Infrastructure/ColorConsole>
 [ColorConsoleLicense]:                                      <https://docs.github.com/en/github/site-policy/github-terms-of-service#d-user-generated-content>
@@ -159,3 +173,5 @@ Perfview
 [7-ZipLicense]:                                             <../3rdParty/7-Zip/LICENSE>
 [7-ZipSourceCode]:                                          <../3rdParty/7-Zip/7z1900-src.7z>
 [7-ZipSourceCode_sourceforgenet]:                           <https://sourceforge.net/projects/sevenzip/files/7-Zip/19.00/7z1900-src.7z/download>
+
+[Squid-Box.SevenZipSharp]:                                   <https://www.nuget.org/packages/Squid-Box.SevenZipSharp/>

--- a/ETWAnalyzer/Commands/ExtractCommand.cs
+++ b/ETWAnalyzer/Commands/ExtractCommand.cs
@@ -36,7 +36,7 @@ namespace ETWAnalyzer.Commands
     {
         internal static readonly string HelpString =
          "ETWAnalyzer [-extract [All, Default or Disk File CPU Memory Exception Stacktag ThreadPool PMC Frequency Power Dns TCP] -filedir/-fd inEtlOrZip [-DryRun] [-symServer NtSymbolPath/MS/Google/syngo] [-keepTemp] [-NoOverwrite] [-pThreads dd] [-nThreads dd]" + Environment.NewLine +
-         "            [-NoReady] [-allCPU] [-Concurrency dd] [-NoIndent] [-LastNDays dd] [-TestsPerRun dd -SkipNTests dd] [-TestRunIndex dd -TestRunCount dd] [-NoTestRunGrouping]  " + Environment.NewLine + 
+         "            [-NoReady] [-allCPU] [-Concurrency dd] [-NoIndent] [-NoCompress] [-LastNDays dd] [-TestsPerRun dd -SkipNTests dd] [-TestRunIndex dd -TestRunCount dd] [-NoTestRunGrouping]  " + Environment.NewLine + 
          "Retrieve data from ETL files and store extracted data in a serialized format in Json in the output directory \\Extract folder." + Environment.NewLine +
          "The data can the be analyzed by other tools or ETWAnalyzer itself which can also analyze the data for specific patterns or issues." + Environment.NewLine +
          "Extract Options are separated by space" + Environment.NewLine +
@@ -77,7 +77,8 @@ namespace ETWAnalyzer.Commands
          " -DryRun              Do not extract. Only print which files would be extracted." + Environment.NewLine + 
          " -NoOverwrite         By default existing Json files are overwritten during a new extraction run. If you want to extract from a large directory only the missing extraction files you can use this option" + Environment.NewLine +
          "                      This way you can have the same extract command line in a script after a profiling run to extract only the newly added profiling data." + Environment.NewLine +
-         " -Indent              By default a not readable non indented json file is written to save space. For readability you can save the json files with extra spaces and line feeds. This increases the file size ca. by 30%." + Environment.NewLine +    
+         " -Indent              By default a not readable non indented json file is written to save space. For readability you can save the json files with extra spaces and line feeds. This increases the file size ca. by 30%." + Environment.NewLine +
+        $" -NoCompress          By default the extracted json files are stored in a 7z archive with the extension {TestRun.CompressedExtractExtension}. Use this flag if you need uncompressed json files." + Environment.NewLine +
          " -recursive           Test data is searched recursively below -filedir" + Environment.NewLine +
          " -filedir/-fd  xxx    Can occur multiple times. If a directory is entered all compressed and contained ETL files are extracted. You can also specify a single etl/zip file." + Environment.NewLine +
         @"                      File queries and exclusions are also supported. E.g. -fd C:\Temp\*error*.etl;!*disk* will extract all etl files in c:\temp containing the name error but exclude the ones which contain disk in the file name" + Environment.NewLine +

--- a/ETWAnalyzer/Commands/LoadSymbolCommand.cs
+++ b/ETWAnalyzer/Commands/LoadSymbolCommand.cs
@@ -137,7 +137,7 @@ namespace ETWAnalyzer.Commands
             };
 
             using SymbolLoader loader = new SymbolLoader(reader);
-            ExtractSerializer ser = new ExtractSerializer();
+            
 
             for(int i=0;i<myInputJsonFiles.Length;i++)
             {
@@ -153,7 +153,8 @@ namespace ETWAnalyzer.Commands
                 {
                     outputFile = Path.Combine(outdir, Path.GetFileName(jsonFile.JsonExtractFileWhenPresent));
                 }
-                ser.Serialize(outputFile, (ETWExtract) jsonFile.Extract);
+                ExtractSerializer ser = new ExtractSerializer(outputFile);
+                ser.Serialize((ETWExtract) jsonFile.Extract);
             }
         }
     }

--- a/ETWAnalyzer/ETWAnalyzer.csproj
+++ b/ETWAnalyzer/ETWAnalyzer.csproj
@@ -89,6 +89,7 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
+    <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.2.24" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/ETWAnalyzer/Extract/CPU/CPUStats.cs
+++ b/ETWAnalyzer/Extract/CPU/CPUStats.cs
@@ -149,13 +149,8 @@ namespace ETWAnalyzer.Extract
                 CPUExtended lret = null;
                 if (DeserializedFileName != null)
                 {
-                    ExtractSerializer ser = new();
-                    string file = ser.GetFileNameFor(DeserializedFileName, ExtractSerializer.ExtendedCPUPostFix);
-                    if (File.Exists(file))
-                    {
-                        using var fileStream = ExtractSerializer.OpenFileReadOnly(file);
-                        lret = ExtractSerializer.Deserialize<CPUExtended>(fileStream);
-                    }
+                    ExtractSerializer ser = new(DeserializedFileName);
+                    lret = ser.Deserialize<CPUExtended>(ExtractSerializer.ExtendedCPUPostFix);
                 }
                 
                 if( lret == null )

--- a/ETWAnalyzer/Extract/ETWExtract.cs
+++ b/ETWAnalyzer/Extract/ETWExtract.cs
@@ -357,13 +357,8 @@ namespace ETWAnalyzer.Extract
             FileIOData lret = FileIO;
             if( lret == null && DeserializedFileName != null)
             {
-                ExtractSerializer ser = new();
-                string file = ser.GetFileNameFor(DeserializedFileName, ExtractSerializer.FileIOPostFix);
-                if (File.Exists(file))
-                {
-                    using var fileStream = ExtractSerializer.OpenFileReadOnly(file);
-                    lret = ExtractSerializer.Deserialize<FileIOData>(fileStream);
-                }
+                ExtractSerializer ser = new(DeserializedFileName);
+                lret = ser.Deserialize<FileIOData>(ExtractSerializer.FileIOPostFix);
             }
             return lret;
         }
@@ -375,12 +370,10 @@ namespace ETWAnalyzer.Extract
             HandleObjectData lret = HandleData;
             if( DeserializedFileName != null)
             {
-                ExtractSerializer ser = new();
-                string file = ser.GetFileNameFor(DeserializedFileName, ExtractSerializer.HandlePostFix);
-                if( File.Exists(file))
+                ExtractSerializer ser = new(DeserializedFileName);
+                lret = ser.Deserialize<HandleObjectData>(ExtractSerializer.HandlePostFix);
+                if (lret != null)
                 {
-                    using var fileStream = ExtractSerializer.OpenFileReadOnly(file);
-                    lret = ExtractSerializer.Deserialize<HandleObjectData>(fileStream);
                     lret.DeserializedFileName = DeserializedFileName;
                 }
             }
@@ -398,15 +391,12 @@ namespace ETWAnalyzer.Extract
             ModuleContainer lret = Modules;
             if (lret == null && DeserializedFileName != null)
             {
-                ExtractSerializer ser = new();
-                string file = ser.GetFileNameFor(DeserializedFileName, ExtractSerializer.ModulesPostFix);
-                if (File.Exists(file))
+                ExtractSerializer ser = new(DeserializedFileName);
+                lret = ser.Deserialize<ModuleContainer>(ExtractSerializer.ModulesPostFix);
+                if (lret != null)
                 {
-                    using var fileStream = ExtractSerializer.OpenFileReadOnly(file);
-                    lret = ExtractSerializer.Deserialize<ModuleContainer>(fileStream);
-                    // Set parent nodes for shared strings and process list of ETWExtract after deserialization
                     lret.Extract = this;
-                    foreach(var module in lret.Modules)
+                    foreach (var module in lret.Modules)
                     {
                         module.Container = lret;
                     }

--- a/ETWAnalyzer/Extract/Handle/HandleObjectData.cs
+++ b/ETWAnalyzer/Extract/Handle/HandleObjectData.cs
@@ -74,13 +74,8 @@ namespace ETWAnalyzer.Extract.Handle
             StackCollection lret = Stacks;
             if (DeserializedFileName != null)
             {
-                ExtractSerializer ser = new();
-                string file = ser.GetFileNameFor(DeserializedFileName, ExtractSerializer.HandleStackPostFix);
-                if (File.Exists(file))
-                {
-                    using var fileStream = ExtractSerializer.OpenFileReadOnly(file);
-                    lret = ExtractSerializer.Deserialize<StackCollection>(fileStream);
-                }
+                ExtractSerializer ser = new(DeserializedFileName);
+                lret = ser.Deserialize<StackCollection>(ExtractSerializer.HandleStackPostFix);
             }
 
             return lret;

--- a/ETWAnalyzer/Extract/TestDataFile.cs
+++ b/ETWAnalyzer/Extract/TestDataFile.cs
@@ -325,7 +325,7 @@ namespace ETWAnalyzer.Extract
         {
             string ext = Path.GetExtension(FileName).ToLowerInvariant();
             string jsonFile = null;
-            if (ext == TestRun.ExtractExtension)
+            if (ext == TestRun.ExtractExtension || ext == TestRun.CompressedExtractExtension)
             {
                 jsonFile = FileName;
             }
@@ -336,14 +336,28 @@ namespace ETWAnalyzer.Extract
                 if (directory?.OutputDirectory != null)
                 {
                     jsonFile = Path.Combine(directory.OutputDirectory, directory.IsDefault ? Program.ExtractFolder : "", fileNameWithoutExtension + TestRun.ExtractExtension);
+                    if (!File.Exists(jsonFile)) // search below 7z file in Extract Folder
+                    {
+                        jsonFile = Path.Combine(directory.OutputDirectory, directory.IsDefault ? Program.ExtractFolder : "", fileNameWithoutExtension + TestRun.CompressedExtractExtension);
+                    }
                 }
-                if( !File.Exists(jsonFile)) // search below 7z file in Extract Folder
+
+                if ( !File.Exists(jsonFile)) // search below 7z file in Extract Folder
                 {
                     jsonFile = Path.Combine(Path.GetDirectoryName(FileName), Program.ExtractFolder, fileNameWithoutExtension + TestRun.ExtractExtension);
                 }
-                if( !File.Exists(jsonFile)) // search side by side of etl/zip file
+                if (!File.Exists(jsonFile)) // search below 7z file in Extract Folder
+                {
+                    jsonFile = Path.Combine(Path.GetDirectoryName(FileName), Program.ExtractFolder, fileNameWithoutExtension + TestRun.CompressedExtractExtension);
+                }
+
+                if ( !File.Exists(jsonFile)) // search side by side of etl/zip file
                 {
                     jsonFile = Path.Combine(Path.GetDirectoryName(FileName), fileNameWithoutExtension + TestRun.ExtractExtension);
+                }
+                if (!File.Exists(jsonFile)) // search side by side of etl/zip file
+                {
+                    jsonFile = Path.Combine(Path.GetDirectoryName(FileName), fileNameWithoutExtension + TestRun.CompressedExtractExtension);
                 }
             }
             return File.Exists(jsonFile) ? jsonFile : null;

--- a/ETWAnalyzer/Extract/TestRun.cs
+++ b/ETWAnalyzer/Extract/TestRun.cs
@@ -42,14 +42,14 @@ namespace ETWAnalyzer.Extract
         internal const string ExtractExtension = ".json";
 
         /// <summary>
-        /// Compressed Json extension
+        /// Compressed Json extension which has all extracted json files stored in one archive.
         /// </summary>
         internal const string CompressedExtractExtension = ".json7z";
 
         /// <summary>
         /// Valid files are compressed ETL files and extracted ETL files, as well as extracted Json files
         /// </summary>
-        static readonly string[] ValidExtensions = new string[] { SevenZExtension, ZipExtension, ETLExtension, ExtractExtension };
+        static readonly string[] ValidExtensions = new string[] { SevenZExtension, ZipExtension, ETLExtension, ExtractExtension, CompressedExtractExtension };
 
         /// <summary>
         /// When between two tests a time gap > 1h exists then map it to a new TestRun

--- a/ETWAnalyzer/Extractors/ExtractSerializer.cs
+++ b/ETWAnalyzer/Extractors/ExtractSerializer.cs
@@ -345,7 +345,7 @@ namespace ETWAnalyzer.Extractors
                 else  // we need to match any files which has not _Dervied_ in its name
                 {
                     string derived = archiveFileNames.Where(x => x.Contains(DerivedFilePart)).FirstOrDefault();
-                    if (derived != null) // use as root file name the derived file name
+                    if (derived != null) // use as root file any derived file because we also want to support additional files in the archive 
                     {
                         string fileNoExt = Path.GetFileNameWithoutExtension(derived);
                         lret = fileNoExt.Substring(0, fileNoExt.IndexOf(DerivedFilePart)) + Path.GetExtension(derived);

--- a/ETWAnalyzer/Extractors/ExtractSerializer.cs
+++ b/ETWAnalyzer/Extractors/ExtractSerializer.cs
@@ -2,10 +2,8 @@
 //// SPDX-License-Identifier:   MIT
 
 
-using Dia2Lib;
 using ETWAnalyzer.Extract;
 using ETWAnalyzer.Extract.Common;
-using ETWAnalyzer.Extract.CPU;
 using ETWAnalyzer.Extract.CPU.Extended;
 using ETWAnalyzer.Extract.FileIO;
 using ETWAnalyzer.Extract.Handle;
@@ -22,8 +20,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ETWAnalyzer.Extractors
 {

--- a/ETWAnalyzer/Extractors/MachineDetailsExtractor.cs
+++ b/ETWAnalyzer/Extractors/MachineDetailsExtractor.cs
@@ -182,7 +182,16 @@ namespace ETWAnalyzer.Extractors
                         continue;
                     }
 
-                    currentPartition.FileSystem = (FileSystemFormat) partition.FileSystem;
+
+                    try
+                    {
+                        currentPartition.FileSystem = (FileSystemFormat)partition.FileSystem;
+                    }
+                    catch (NotImplementedException ex)
+                    {
+                        Logger.Warn($"File system could not be determined for partition Drive {partition.DriveLetter.ToString()}, {ex}");
+                    }
+
                     currentPartition.Drive = partition.DriveLetter.ToString();
                     currentPartition.FreeSizeGiB = partition.FreeCapacity.TotalGibibytes;
                     currentPartition.TotalSizeGiB = partition.UsedCapacity.TotalGibibytes + partition.FreeCapacity.TotalGibibytes;

--- a/ETWAnalyzer/Infrastructure/ReusableMemoryStream.cs
+++ b/ETWAnalyzer/Infrastructure/ReusableMemoryStream.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace ETWAnalyzer.Infrastructure
 {
+    /// <summary>
+    /// Do not close memory stream on dispose, so we can reuse it
+    /// </summary>
     internal class ReusableMemoryStream : MemoryStream
     {
         protected override void Dispose(bool disposing)

--- a/ETWAnalyzer/Infrastructure/ReusableMemoryStream.cs
+++ b/ETWAnalyzer/Infrastructure/ReusableMemoryStream.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ETWAnalyzer.Infrastructure
+{
+    internal class ReusableMemoryStream : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            
+        }
+    }
+}

--- a/ETWAnalyzer_iTest/ProgramTestsLong.cs
+++ b/ETWAnalyzer_iTest/ProgramTestsLong.cs
@@ -309,8 +309,8 @@ namespace ETWAnalyzer_iTest
             if (IsSymbolServerReachable())
             {
                 // Create a changed file to 
-                ExtractSerializer ser = new ExtractSerializer();
-                ser.Serialize(resolvedJson, RemoveUnresolvedSymbolsExceptForDwmRedir(extract2.Extract));
+                ExtractSerializer ser = new ExtractSerializer(resolvedJson);
+                ser.Serialize(RemoveUnresolvedSymbolsExceptForDwmRedir(extract2.Extract));
 
 
                 // resolve a second time with more symbols which should lead some more resolved files

--- a/ETWAnalyzer_uTest/Extractors/ExtractSerializerTests.cs
+++ b/ETWAnalyzer_uTest/Extractors/ExtractSerializerTests.cs
@@ -1,0 +1,67 @@
+﻿using ETWAnalyzer.Extractors;
+using Microsoft.Windows.EventTracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ETWAnalyzer_uTest.Extractors
+{
+    public class ExtractSerializerTests
+    {
+        [Fact]
+        public void Can_Match_ExpectedFiles_FromArchive()
+        {
+            string rootFileName = "Test.json";
+            ExtractSerializer ser = new(rootFileName);
+            string extended = ser.GetFileNameFor(ExtractSerializer.ExtendedCPUPostFix);
+
+            List<string> zipFileNames = new List<string> { rootFileName, extended };
+
+            Assert.Equal(rootFileName, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), rootFileName));
+            Assert.Equal(extended, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), extended));
+        }
+
+
+        [Fact]
+        public void Can_Match_RenamedArchive_FromArchive()
+        {
+            string rootFileName = "Test.json";
+            ExtractSerializer ser = new(rootFileName);
+            string extended = ser.GetFileNameFor(ExtractSerializer.ExtendedCPUPostFix);
+
+            List<string> zipFileNames = new List<string> { rootFileName, extended };
+
+            string renamedRoot = rootFileName.Replace("Test", "NewName");
+            string renamedExtended = extended.Replace("Test", "NewName");
+
+
+            Assert.Equal(rootFileName, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), renamedRoot));
+            Assert.Equal(extended, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), renamedExtended));
+        }
+
+
+        [Fact]
+        public void Can_Match_RenamedArchive_WithAdditionalFile()
+        {
+            string rootFileName = "Test.json";
+            string additionalFile = "Other.json";
+            ExtractSerializer ser = new(rootFileName);
+            string extended = ser.GetFileNameFor(ExtractSerializer.ExtendedCPUPostFix);
+
+            List<string> zipFileNames = new List<string> { additionalFile, rootFileName, extended };
+
+            string renamedRoot = rootFileName.Replace("Test", "NewName");
+            string renamedExtended = extended.Replace("Test", "NewName");
+
+
+            Assert.Equal(rootFileName, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), renamedRoot));
+            Assert.Equal(extended, ExtractSerializer.MatchArchiveFileName(zipFileNames.AsReadOnly(), renamedExtended));
+
+        }
+
+
+    }
+}


### PR DESCRIPTION
Currently every xxx.etl file results in one or multiple extracted json files.
   - xx.json
   - xx_Derived_Modules.json
   - xx_Derived_FileIO.json
   - xx_Derived_CPUExtended.json
   - xx_Derived_Handle.json
   - xx_Derived_HandleStacks.json

These files are getting more over time. They are hard to rename and use quite some space (especially handle data). 
Support to generated one compressed archive with a custom file extension .json7z where all of the json files are put into would be good way to spare disk space and reduce file calls especially on a network drive. 

New Approach

   - xx.json7z

This is then the one and only file which can also be renamed as you like without disturbing query logic because ETWAnalyzer can still find by file name matching the corresponding json files. The .json7z file is a 7z archive which also supports added unrelated files to e.g. store your own derived data in this file.