### PR TITLE
Configurable columns, -TimeDigits and -Console load files

### DIFF
--- a/ETWAnalyzer/Commands/ConsoleCommand.cs
+++ b/ETWAnalyzer/Commands/ConsoleCommand.cs
@@ -493,7 +493,12 @@ namespace ETWAnalyzer.Commands
         /// <param name="args"></param>
         public ConsoleCommand(string[] args) : base(args)
         {
-
+            // skip -console argument and treat rest as input file names
+            string[] fileCandidates = args.Skip(1).Where(x => x.ToLowerInvariant() != "-fd").ToArray();
+            if( fileCandidates.Length > 0 ) 
+            {
+                Load(fileCandidates, false);
+            }
         }
 
 

--- a/ETWAnalyzer/Commands/ConsoleCommand.cs
+++ b/ETWAnalyzer/Commands/ConsoleCommand.cs
@@ -4,11 +4,8 @@
 using ETWAnalyzer.Extract;
 using ETWAnalyzer.Infrastructure;
 using ETWAnalyzer.ProcessTools;
-using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -21,28 +18,44 @@ namespace ETWAnalyzer.Commands
     {
         public override string Help => "";
 
+        string TimeFormatString = null;
+        string TimeDigitString = null;
+        string ProcessFmt = null;
+
+        bool ShowFullFileNameFlag { get; set; }
+        /// <summary>
+        /// Currently loaded files
+        /// </summary>
+        Lazy<SingleTest>[] myInputFiles;
+
         class ConsoleHelpCommand : ArgParser
         {
             public override string Help =>
-                ".cls                               "+ Environment.NewLine + 
+                ".cls"+ Environment.NewLine + 
                 "   Clear screen." + Environment.NewLine +
-               $".dump xxx [ -fd *usecase1* ]         " + Environment.NewLine + 
+               $".dump xxx [ -fd *usecase1* ]" + Environment.NewLine + 
                 "   Query loaded file/s. Options are the same as in -Dump command. e.g. .dump CPU will print CPU metrics." + Environment.NewLine +
                 "     -fd *filter*    Filter loaded files which are queried. Filter is applied to full path file name." + Environment.NewLine +  
                $"   Allowed values are {DumpCommand.AllDumpCommands}" + Environment.NewLine +
-                ".load [-all] file1.json file2.json ...    " + Environment.NewLine + 
+                ".load [-all] file1.json file2.json .." + Environment.NewLine + 
                 "     -all    Fully load all json files during load. By default the files are fully loaded during the dump command." + Environment.NewLine +
                 "   Load one or more data files. Use . to load all files in current directory. Previously loaded files are removed." + Environment.NewLine +
-                ".load+ file.json                   " + Environment.NewLine + 
+                ".load+ file.json" + Environment.NewLine + 
                 "   Add file to list of loaded files but keep other files." + Environment.NewLine +  
-                ".list                              " + Environment.NewLine + 
+                ".list" + Environment.NewLine + 
                 "   List loaded files" + Environment.NewLine +
-                ".quit or .q                        "+Environment.NewLine + 
+                ".processfmt timefmt" + Environment.NewLine +
+                "   Display for process start/end marker not +- but actual time and duration." + Environment.NewLine +
+                ".quit or .q"+Environment.NewLine + 
                 "   Quit ETWAnalyzer" + Environment.NewLine +
-                ".unload                            "+Environment.NewLine + 
+                ".unload"+Environment.NewLine + 
                 "   Unload all files if no parameter is passed. Otherwise only the passed files are unloaded from the file list." + Environment.NewLine +
-                ".sffn                              " +Environment.NewLine + 
+                ".sffn" +Environment.NewLine + 
                 "   Enable/disable -ShowFullFileName to display full path of output files." + Environment.NewLine +
+                ".timedigits n" + Environment.NewLine + 
+                "   Set time precision (0-6)." + Environment.NewLine +
+                ".timefmt fmt [precision]" + Environment.NewLine + 
+               $"   Set time display format ({String.Join(" ", Enum.GetNames(typeof(EventDump.DumpBase.TimeFormats)).Where(x=>x!="None"))}) and precision (0-6) where default is 3." + Environment.NewLine +
                 "Pressing Ctrl-C will cancel current command, Ctrl-Break will terminate";
 
             public override void Parse()
@@ -57,11 +70,6 @@ namespace ETWAnalyzer.Commands
             public ConsoleHelpCommand(string[] args) : base(args)
             { }
         }
-
-        /// <summary>
-        /// Currently loaded files
-        /// </summary>
-        Lazy<SingleTest>[] myInputFiles;
 
 
         public override void Run()
@@ -92,8 +100,6 @@ namespace ETWAnalyzer.Commands
             }
         }
 
-        bool ShowFullFileNameFlag { get; set; }
-
         /// <summary>
         /// Command syntax is first string is command name and all following arguments are arguments for that command like in the command line
         /// </summary>
@@ -112,7 +118,10 @@ namespace ETWAnalyzer.Commands
                 ".dump" => CreateDumpCommand(args),
                 ".exit" => new QuitCommand(args),
                 ".list" => ListFiles(args),
+                ".processfmt" => SetProcessFmt(args),
                 ".sffn" => ShowFullFileName(args),
+                ".timedigits" => SetTimeDigits(args),
+                ".timefmt" => SetTimeFormat(args),
                 ".quit" => new QuitCommand(args),
                 ".q" => new QuitCommand(args),
                 "q" => new QuitCommand(args),
@@ -176,6 +185,51 @@ namespace ETWAnalyzer.Commands
             return lret;
         }
 
+        private ICommand SetTimeDigits(string[] args)
+        {
+            ICommand lret = null;
+            TimeDigitString = null;
+
+            if (args.Length > 0)
+            {
+                TimeDigitString = args[0];
+            }
+            return lret;
+        }
+
+        private ICommand SetTimeFormat(string[] args)
+        {
+            ICommand lret = null;
+            TimeFormatString = null;
+            TimeDigitString = null;
+
+            if ( args.Length > 1 )
+            {
+                TimeFormatString = args[0]; 
+
+                if( args.Length > 1 )
+                {
+                    TimeDigitString = args[1];  
+                }
+            }
+            return lret;
+        }
+
+
+        private ICommand SetProcessFmt(string[] args)
+        {
+            ICommand lret = null;
+            ProcessFmt = null;
+
+            if (args.Length > 0)
+            {
+                ProcessFmt = args[0];
+            }
+
+            return lret;
+        }
+
+
         /// <summary>
         /// 
         /// </summary>
@@ -203,7 +257,7 @@ namespace ETWAnalyzer.Commands
 
             return lret;
         }
-
+        
         /// <summary>
         /// Create dump command from filtered list of arguments.
         /// </summary>
@@ -212,7 +266,26 @@ namespace ETWAnalyzer.Commands
         DumpCommand CreateDumpCommand(string[] args)
         {
             var argsAndTests = ApplyFileDirFilter(args);
-            return new DumpCommand(argsAndTests.Item1, argsAndTests.Item2)
+            List<string> filteredArgs = argsAndTests.Item1.ToList();
+            if( this.TimeDigitString != null )
+            {
+                filteredArgs.Add("-TimeDigits");
+                filteredArgs.Add(TimeDigitString);
+            }
+
+            if( this.TimeFormatString != null ) 
+            {
+                filteredArgs.Add("-TimeFmt");
+                filteredArgs.Add(TimeFormatString);
+            }
+
+            if (ProcessFmt != null)
+            {
+                filteredArgs.Add("-ProcessFmt");
+                filteredArgs.Add(ProcessFmt);
+            }
+
+            return new DumpCommand(filteredArgs.ToArray(), argsAndTests.Item2)
             {
                 ShowFullFileName = ShowFullFileNameFlag,
             };

--- a/ETWAnalyzer/Commands/DumpCommand.cs
+++ b/ETWAnalyzer/Commands/DumpCommand.cs
@@ -1748,6 +1748,10 @@ namespace ETWAnalyzer.Commands
                     case "-timedigits":
                         string timedigits = GetNextNonArg("-timedigits");
                         TimeDigits = int.Parse(timedigits, CultureInfo.InvariantCulture);
+                        if( TimeDigits < 0 || TimeDigits > 6)
+                        {
+                            throw new NotSupportedException($"-Timedigits supports only values from 0-6. Value was: {TimeDigits}.");
+                        }
                         break;
                     case "-properties":
                         Properties = GetNextNonArg("-properties");

--- a/ETWAnalyzer/Commands/HelpCommand.cs
+++ b/ETWAnalyzer/Commands/HelpCommand.cs
@@ -17,7 +17,7 @@ namespace ETWAnalyzer.Commands
         private static readonly string HelpString =
            $"ETWAnalyzer {FileVersionInfo.GetVersionInfo(Process.GetCurrentProcess().MainModule.FileName).FileVersion}" + Environment.NewLine +
             " ETWAnalyzer [green]-help[/green] [Extract, Dump, Console, Convert or LoadSymbol]  Get further information about the specific sub command" + Environment.NewLine +
-            " ETWAnalyzer [green]-Console[/green]" + Environment.NewLine +
+            " ETWAnalyzer [green]-Console [input files] [/green]" + Environment.NewLine +
             "        Interactive mode. Useful if working with bigger data sets without the need to reload data on every query. Enter .help to get more information." + Environment.NewLine +
             " ETWAnalyzer [green]-Convert[/green] -filedir xx.etl -pid dd [-perthread]" + Environment.NewLine +
             "        Convert from an ETL File a process to a speedscope json file." + Environment.NewLine +

--- a/ETWAnalyzer/Documentation/DumpProcessCommand.md
+++ b/ETWAnalyzer/Documentation/DumpProcessCommand.md
@@ -55,6 +55,8 @@ Supported values for *-TimeFmt* are:
 | UTC|  2022-02-04 08:56:34.670|
 | UTCTime| 08:56:34.670|
 
+## Time Precision
+The default time precision is ms, but it can be configured by using the ```-TimeDigits d``` flag to display time from 0-6 decimal places.
 
 ## Process Selection/Filters
 

--- a/ETWAnalyzer/Documentation/DumpTCPCommand.md
+++ b/ETWAnalyzer/Documentation/DumpTCPCommand.md
@@ -121,9 +121,10 @@ On Windows Server you can change the Template settings with *Set-NetTCPSetting* 
 TCP template if the automatic detection mechanism does not work for you. 
 On client operating systems you cannot change the TCP template settings in a supported way (Windows 10,11). The most important setting is MinRto(ms) which defines
 the minimum retransmission timeout. It is the time the TCP stack of Windows will resend packets if after the MinRto time no ACK from the receiver was returned.
-If that did not work Windows will resend the missing packet with a delay of RTO_i which is proportional to i^3 where i is th i-th resend try.
-After n failed retransmits Windows resets the TCP connection by sending a RST packet and close the connection on his side. 
-
+If that did not work Windows will resend the missing packet with a delay of MinRto where the delay is doubled on each round until ca. 9 retransmissions have occurred.
+After n failed retransmits Windows waits additionally ca. 10s and then resets the TCP connection by sending a RST packet (TcpDisconnectTcbRtoTimeout event) and close the connection on his side. 
+If the connection could not be established after the initial SYN packet because no one did answer TcpConnectRestransmit events are logged which can be used to check
+if invalid or not reachable hosts were tried to connect to.
 
 ## Recording Hints
 The *Microsoft-Windows-TCPIP* provider traces many events which are internal to how TCP works on Windows. To record data for some minutes you need to filter out the irrelevant events.

--- a/ETWAnalyzer/ETWAnalyzer.csproj
+++ b/ETWAnalyzer/ETWAnalyzer.csproj
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Siemens-Healthineers/ETWAnalyzer</PackageProjectUrl>
     <PackageReadmeFile>ProgramaticAccess.md</PackageReadmeFile>
-    <Version>3.0.0.9</Version>
+    <Version>3.0.0.10</Version>
     <Platforms>x64</Platforms>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>

--- a/ETWAnalyzer/EventDump/DumpBase.cs
+++ b/ETWAnalyzer/EventDump/DumpBase.cs
@@ -25,12 +25,17 @@ namespace ETWAnalyzer.EventDump
 
         protected bool GetOverrideFlag(string column, bool defaultFlag)
         {
+            // if only disable rules are active we leave the enabled defaults 
+            // otherwise just the enabled/disabled columns are enabled
+            bool onlyDisableRules = ColumnConfiguration.Values.All(x => x == false);
+
             if(ColumnConfiguration.TryGetValue(column, out bool overrideFlag))
             {
                 return overrideFlag;
             }
 
-            return defaultFlag;
+            // all other columns are disabled if explicit enable columns are configured.
+            return onlyDisableRules ? defaultFlag : false;
         }
 
 
@@ -435,6 +440,18 @@ namespace ETWAnalyzer.EventDump
                 return lret;
             }
 
+        }
+
+        /// <summary>
+        /// Get maximum string length for column width calculation.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collection">items to be formatted</param>
+        /// <param name="getter">String extractor</param>
+        /// <returns>Maximum string length returned by getter for all items.</returns>
+        protected static int GetMaxLength<T>(IList<T> collection, Func<T,string> getter)
+        {
+            return collection.Max(x => (getter(x)?.Length).GetValueOrDefault());
         }
 
         #region IDisposable Support

--- a/ETWAnalyzer/EventDump/DumpBase.cs
+++ b/ETWAnalyzer/EventDump/DumpBase.cs
@@ -202,20 +202,22 @@ namespace ETWAnalyzer.EventDump
             }
         }
 
+        int WidthDiffTo3 { get => OverridenOrDefaultTimePrecision - 3; }
+
         protected int GetWidth(TimeFormats format)
         {
             return format switch
             {
-                TimeFormats.s => SecondsColWidth,
-                TimeFormats.second => SecondsColWidth,
+                TimeFormats.s => SecondsColWidth + WidthDiffTo3,
+                TimeFormats.second => SecondsColWidth + WidthDiffTo3,
 
-                TimeFormats.HereTime => TimeFormatColWidth,
-                TimeFormats.LocalTime => TimeFormatColWidth,
-                TimeFormats.UTCTime => TimeFormatColWidth,
+                TimeFormats.HereTime => TimeFormatColWidth+ WidthDiffTo3,
+                TimeFormats.LocalTime => TimeFormatColWidth + WidthDiffTo3,
+                TimeFormats.UTCTime => TimeFormatColWidth + WidthDiffTo3,
                 
-                TimeFormats.Here => DateTimeColWidth,
-                TimeFormats.Local => DateTimeColWidth,
-                TimeFormats.UTC => DateTimeColWidth,
+                TimeFormats.Here => DateTimeColWidth + WidthDiffTo3,
+                TimeFormats.Local => DateTimeColWidth + WidthDiffTo3,
+                TimeFormats.UTC => DateTimeColWidth + WidthDiffTo3,
                 _ => 0 // should not happen
             };
         }

--- a/ETWAnalyzer/EventDump/DumpExceptions.cs
+++ b/ETWAnalyzer/EventDump/DumpExceptions.cs
@@ -189,7 +189,7 @@ namespace ETWAnalyzer.EventDump
                 string directory = match.Module?.ModulePath ?? "";
                 WriteCSVLine(CSVOptions, GetDateTimeString(match.TimeStamp, match.SessionStart, TimeFormatOption), match.Type, match.Message, match.Process.GetProcessWithId(UsePrettyProcessName), 
                     match.Process.GetProcessName(UsePrettyProcessName), match.Process.SessionId, match.Process.StartTime,
-                    match.Process.CmdLine, match.Stack, match.TestCase, match.BaseLine, GetDateTimeString(match.PerformedAt), match.SourceFile,
+                    match.Process.CmdLine, match.Stack, match.TestCase, match.BaseLine, match.PerformedAt, match.SourceFile,
                     fileVersion, versionString, productVersion, productName, description, directory);
             }
         }

--- a/ETWAnalyzer/EventDump/DumpModuleVersions.cs
+++ b/ETWAnalyzer/EventDump/DumpModuleVersions.cs
@@ -88,7 +88,7 @@ namespace ETWAnalyzer.EventDump
                 switch (Mode)
                 {
                     case PrintMode.Module:
-                        string moduleBuildData = GetDateTimeString(MachineDetailsExtractor.GetBuildDate(new Version(data.ModuleVersion.Version)));
+                        string moduleBuildData = MachineDetailsExtractor.GetBuildDate(new Version(data.ModuleVersion.Version)).ToString();
                         int diffDays = (int)(MachineDetailsExtractor.GetBuildDate(new Version(data.MainModuleVersion.Version)) - MachineDetailsExtractor.GetBuildDate(new Version(data.ModuleVersion.Version))).TotalDays;
                         diffDays = Math.Abs(diffDays) > 400 ? 400 : diffDays;
                         WriteCSVLine(CSVOptions, data.TestName, data.Duration, data.Machine, data.TestDate, data.MainModuleVersion.Version, data.ModuleVersion.Module, data.ModuleVersion.Version, moduleBuildData, diffDays, data.SourceFile);

--- a/ETWAnalyzer/EventDump/DumpObjectRef.cs
+++ b/ETWAnalyzer/EventDump/DumpObjectRef.cs
@@ -87,6 +87,7 @@ namespace ETWAnalyzer.EventDump
 
         public override List<MatchData> ExecuteInternal()
         {
+            DefaultTimePrecision = 6; // we need us time precision by default
             HarmonizeFilterSettings();
 
             List<MatchData> lret = ReadFileData();
@@ -920,7 +921,7 @@ namespace ETWAnalyzer.EventDump
 
         void PrintEventHeader(IStackEventBase ev, IETWExtract resolver, string name, string beforeProc = null)
         {
-            string timeStr = base.GetTimeString(ev.GetTime(resolver.SessionStart), resolver.SessionStart, this.TimeFormatOption, 6);
+            string timeStr = base.GetTimeString(ev.GetTime(resolver.SessionStart), resolver.SessionStart, this.TimeFormatOption);
             ColorConsole.WriteEmbeddedColorLine($"\t{timeStr} [magenta]{GetProcessId(ev.ProcessIdx, resolver),5}[/magenta]/{ev.ThreadId,-5} {name} {beforeProc}[magenta]{GetProcessAndStartStopTags(ev.ProcessIdx, resolver,false)}[/magenta] ", null, true);
         }
 

--- a/ETWAnalyzer/Extract/Network/Tcp/ITcpConnection.cs
+++ b/ETWAnalyzer/Extract/Network/Tcp/ITcpConnection.cs
@@ -66,6 +66,21 @@ namespace ETWAnalyzer.Extract.Network.Tcp
         DateTimeOffset? TimeStampOpen { get; }
 
         /// <summary>
+        /// Time when data was last sent
+        /// </summary>
+        public DateTimeOffset? LastSent { get; }
+
+        /// <summary>
+        /// Time when data was last received
+        /// </summary>
+        public DateTimeOffset? LastReceived { get; }
+
+        /// <summary>
+        /// Time when connection was closed due to retransmission timeout
+        /// </summary>
+        public DateTimeOffset? RetransmitTimeout { get; }
+
+        /// <summary>
         /// Check if connection was active at a given time.
         /// </summary>
         /// <param name="tcb">TCB pointer value of etw event which uses it to correlate events.</param>

--- a/ETWAnalyzer/Extract/Network/Tcp/TcpConnection.cs
+++ b/ETWAnalyzer/Extract/Network/Tcp/TcpConnection.cs
@@ -11,6 +11,7 @@ namespace ETWAnalyzer.Extract.Network.Tcp
 {
     /// <summary>
     /// Contains information about one TCP connection (Tcb, open/close time, src/dst ip and ports). Fired during inital handshake.
+    /// Serialized to Json
     /// </summary>
     public class TcpConnection : ITcpConnection
     {
@@ -45,7 +46,6 @@ namespace ETWAnalyzer.Extract.Network.Tcp
         /// </summary>
         public string LastTcpTemplate { get; }
 
-
         /// <summary>
         /// Received data over duration of trace
         /// </summary>
@@ -71,6 +71,24 @@ namespace ETWAnalyzer.Extract.Network.Tcp
         /// </summary>
         public ETWProcessIndex ProcessIdx { get; }
 
+
+        /// <summary>
+        /// Time when data was last sent
+        /// </summary>
+        public DateTimeOffset? LastSent { get; internal set; }
+
+        /// <summary>
+        /// Time when data was last received
+        /// </summary>
+        public DateTimeOffset? LastReceived { get; }
+
+
+        /// <summary>
+        /// Time when connection was closed due to retransmission timeout
+        /// </summary>
+        public DateTimeOffset? RetransmitTimeout { get; }
+
+
         /// <summary>
         /// Socket connect/disconnect time format string
         /// </summary>
@@ -78,7 +96,7 @@ namespace ETWAnalyzer.Extract.Network.Tcp
 
 
         /// <summary>
-        /// Create an instance
+        /// Create an instance which is used also by Json.NET to deserialize this object.
         /// </summary>
         /// <param name="tcb"></param>
         /// <param name="localipandPort"></param>
@@ -91,10 +109,13 @@ namespace ETWAnalyzer.Extract.Network.Tcp
         /// <param name="datagramsSent"></param>
         /// <param name="datagramsReceived"></param>
         /// <param name="processIdx"></param>
+        /// <param name="lastReceived"></param>
+        /// <param name="lastSent"></param>
+        /// <param name="retransmitTimeout"></param>
         /// <exception cref="ArgumentNullException">When localipandPort or remoteipAndPort are null.</exception>
         public TcpConnection(ulong tcb, SocketConnection localipandPort, SocketConnection remoteipAndPort, DateTimeOffset? timeStampOpen, DateTimeOffset? timeStampClose, string lastTcpTemplate,
             ulong bytesSent, int datagramsSent,
-            ulong bytesReceived, int datagramsReceived, ETWProcessIndex processIdx)
+            ulong bytesReceived, int datagramsReceived, ETWProcessIndex processIdx, DateTimeOffset? retransmitTimeout, DateTimeOffset? lastSent, DateTimeOffset? lastReceived)
         {
             Tcb = tcb;
             LocalIpAndPort = localipandPort ?? throw new ArgumentNullException(nameof(localipandPort));
@@ -107,6 +128,9 @@ namespace ETWAnalyzer.Extract.Network.Tcp
             DatagramsSent = datagramsSent;
             DatagramsReceived = datagramsReceived;
             ProcessIdx = processIdx;
+            RetransmitTimeout = retransmitTimeout;
+            LastSent = lastSent;    
+            LastReceived = lastReceived;  
         }
 
 

--- a/ETWAnalyzer/Extractors/TCP/TcpDisconnectTcbRtoTimeout.cs
+++ b/ETWAnalyzer/Extractors/TCP/TcpDisconnectTcbRtoTimeout.cs
@@ -1,0 +1,38 @@
+﻿//// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.Extract.Network.Tcp;
+using ETWAnalyzer.TraceProcessorHelpers;
+using Microsoft.Windows.EventTracing.Events;
+using System;
+
+namespace ETWAnalyzer.Extractors.TCP
+{
+    /// <summary>
+    /// Fired when connection is reset after the maximum number of retransmissions Microsoft-Windows-TCPIP/TcpConnectRestransmit in case of
+    /// connection establishment issues, or TcpDataTransferRetransmitRound after connecion has been established have occurred. 
+    /// </summary>
+    internal class TcpDisconnectTcbRtoTimeout
+    {
+        // Fields: Tcb:Pointer, LocalIpAndPort, RemoteIpAndPort, Status, Compartment, ... 
+        public ulong Tcb { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// not yet parsed.
+        /// </summary>
+        public int Compartment { get; private set; }
+
+        public SocketConnection LocalIpAndPort { get; private set; }
+        public SocketConnection RemoteIpAndPort { get; private set; }
+
+        public TcpDisconnectTcbRtoTimeout(IGenericEvent ev)
+        {
+            Tcb = (ulong)ev.Fields[TcpETWConstants.TcbField].AsAddress.Value;
+            Timestamp = ev.Timestamp.DateTimeOffset;
+            LocalIpAndPort = new SocketConnection(ev.Fields[TcpETWConstants.LocalAddressField].AsSocketAddress.ToIPEndPoint());
+            RemoteIpAndPort = new SocketConnection(ev.Fields[TcpETWConstants.RemoteAddressField].AsSocketAddress.ToIPEndPoint());
+        }
+    }
+}

--- a/ETWAnalyzer/Extractors/TCP/TcpRequestConnect.cs
+++ b/ETWAnalyzer/Extractors/TCP/TcpRequestConnect.cs
@@ -1,19 +1,12 @@
 ﻿//// SPDX-FileCopyrightText:  © 2023 Siemens Healthcare GmbH
 //// SPDX-License-Identifier:   MIT
 
-
 using ETWAnalyzer.Extract;
 using ETWAnalyzer.Extract.Network.Tcp;
 using ETWAnalyzer.TraceProcessorHelpers;
-using Microsoft.Windows.EventTracing;
 using Microsoft.Windows.EventTracing.Events;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ETWAnalyzer.Extractors.TCP
 {
@@ -97,6 +90,7 @@ namespace ETWAnalyzer.Extractors.TCP
 
         public DateTimeOffset? TimeStampOpen { get;  }
         public DateTimeOffset? TimeStampClose { get; internal set; }
+        public DateTimeOffset? TCPRetansmitTimeout { get; internal set; }
 
         public SocketConnection LocalIpAndPort { get;  }
         public SocketConnection RemoteIpAndPort { get; }

--- a/ETWAnalyzer/Infrastructure/ColumnDefinition.cs
+++ b/ETWAnalyzer/Infrastructure/ColumnDefinition.cs
@@ -26,6 +26,11 @@ namespace ETWAnalyzer.Infrastructure
         public string Name { get; set; }
 
         /// <summary>
+        /// String which is printed at each row
+        /// </summary>
+        public string Prefix { get; set; } = "";
+
+        /// <summary>
         /// Color in which the text is printed
         /// </summary>
         public ConsoleColor? Color { get; set; }
@@ -35,11 +40,18 @@ namespace ETWAnalyzer.Infrastructure
         /// </summary>
         public bool Enabled { get; set; } = true;
 
+
+        int myDataWidth;
         /// <summary>
         /// Column width excluding extra space to separate columns in output.
         /// When zero then the column data is simply appended which in effect turns wrapping off.
+        /// Minimum non zero data width is 3
         /// </summary>
-        public int DataWidth { get; set; }
+        public int DataWidth 
+        { 
+            get => myDataWidth;
+            set => myDataWidth = value > 0 ? Math.Max(3, value) : Math.Max(0,value); 
+        }
 
     }
 }

--- a/ETWAnalyzer/Infrastructure/ColumnDefinition.cs
+++ b/ETWAnalyzer/Infrastructure/ColumnDefinition.cs
@@ -1,0 +1,45 @@
+﻿//// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ETWAnalyzer.Infrastructure
+{
+
+    /// <summary>
+    /// Defines an output column which can contain multiline data.
+    /// </summary>
+    internal class ColumnDefinition
+    {
+        /// <summary>
+        /// Column title which is printed to console
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Symbolic name which is referenced by -Column property to enabled/disable specific columns
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Color in which the text is printed
+        /// </summary>
+        public ConsoleColor? Color { get; set; }
+
+        /// <summary>
+        /// When false column will not be printed.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Column width excluding extra space to separate columns in output.
+        /// When zero then the column data is simply appended which in effect turns wrapping off.
+        /// </summary>
+        public int DataWidth { get; set; }
+
+    }
+}

--- a/ETWAnalyzer/Infrastructure/ColumnFormatter.cs
+++ b/ETWAnalyzer/Infrastructure/ColumnFormatter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿//// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ETWAnalyzer/Infrastructure/MultilineFormatter.cs
+++ b/ETWAnalyzer/Infrastructure/MultilineFormatter.cs
@@ -62,7 +62,9 @@ namespace ETWAnalyzer.Infrastructure
                     throw new NotSupportedException($"Data is missing for column {curColumn.Title}.");
                 }
 
-                string nextData = curColumn.Enabled ? GetLine(curColumn, columnData[idx], lineNo, false) : null;
+                string stringToFormat = isHeader ? columnData[idx] : (String.IsNullOrEmpty(columnData[idx]) ? columnData[idx] : curColumn.Prefix + columnData[idx]);    
+
+                string nextData = curColumn.Enabled ? GetLine(curColumn, stringToFormat, lineNo, false) : null;
                 if( nextData != null)
                 {
                     columns.Add(new KeyValuePair<string, ColumnDefinition>(nextData, curColumn));
@@ -132,7 +134,6 @@ namespace ETWAnalyzer.Infrastructure
             while (true)
             {
                 List<KeyValuePair<string, ColumnDefinition>> columns = GetCombinedFormattedLine(lineNo, isHeader, columnData.ToArray());
-                
 
                 if (columns.Count  == 0 )
                 {

--- a/ETWAnalyzer/Infrastructure/MultilineFormatter.cs
+++ b/ETWAnalyzer/Infrastructure/MultilineFormatter.cs
@@ -1,0 +1,177 @@
+﻿//// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.ProcessTools;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ETWAnalyzer.Infrastructure
+{
+    /// <summary>
+    /// The MultiLineFormatter class is responsible for printing multiline column data to the console with proper wrapping of output. 
+    /// It is used to format and display tabular data in a visually appealing way.
+    /// </summary>
+    /// <remarks>
+    /// The class has the following key features:
+    /// 	Columns Property: This property represents the columns that will be printed. It is an array of ColumnDefinition objects.
+    /// 	Constructor: The class has a constructor that accepts a variable number of ColumnDefinition objects.These objects define the properties of each column, such as the title, data width, and color.
+    /// 	Print Methods: The class provides two overloaded Print methods.The first method is used to print a line of data, and the second method is used to print column titles.Both methods accept a boolean parameter addNewline to indicate whether a new line should be added after printing.
+    /// Overall, the MultiLineFormatter class provides a convenient way to format and print multiline column data to the console, making it easier to display tabular data in a readable format.
+    /// </remarks>
+    internal class MultiLineFormatter
+    {
+        /// <summary>
+        /// Columns which are printed.
+        /// </summary>
+        public ColumnDefinition[] Columns { get; set; }
+
+        /// <summary>
+        /// Used for unit testing 
+        /// </summary>
+        internal Action<string, ConsoleColor?> Printer = ColorConsole.Write;
+
+        /// <summary>
+        /// Create a formatter with a given set of columns
+        /// </summary>
+        /// <param name="columns"></param>
+        public MultiLineFormatter(params ColumnDefinition[] columns)
+        {
+            Columns = columns;
+        }
+
+        /// <summary>
+        /// Get wrapped data with proper alignment. Headers are left aligned, while row data is right aligned to get proper
+        /// number alignment.
+        /// </summary>
+        /// <param name="lineNo">Starts with 0</param>
+        /// <param name="isHeader">When header is true data is left aligned.</param>
+        /// <param name="columnData">Row data to print. The count of columnData elements must match the number of (including disabled) columns.</param>
+        /// <returns>List of column data to print with their column definitions. If line contains no data the list is empty.</returns>
+        /// <exception cref="NotSupportedException"></exception>
+        private List<KeyValuePair<string,ColumnDefinition>> GetCombinedFormattedLine(int lineNo, bool isHeader, params string[] columnData)
+        {
+            List<KeyValuePair<string, ColumnDefinition>> columns = new();
+            
+            bool allEmpty = true;
+            int idx = 0;
+            foreach(ColumnDefinition curColumn in Columns)
+            {
+                if( columnData.Length <= idx )
+                {
+                    throw new NotSupportedException($"Data is missing for column {curColumn.Title}.");
+                }
+
+                string nextData = curColumn.Enabled ? GetLine(curColumn, columnData[idx], lineNo, false) : null;
+                if( nextData != null)
+                {
+                    columns.Add(new KeyValuePair<string, ColumnDefinition>(nextData, curColumn));
+                    allEmpty = (allEmpty && nextData == "") ? true : false;
+                }
+
+                idx++;
+            }
+
+            if( !allEmpty)
+            {
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    var current = columns[i];
+
+                    if (current.Value.DataWidth > 0)
+                    {
+                        columns[i] = new KeyValuePair<string, ColumnDefinition>(columns[i].Key.WithWidth(isHeader ? (-1) * current.Value.DataWidth : current.Value.DataWidth) + " ", current.Value);
+                    }
+                }
+            }
+
+            if (allEmpty)
+            {
+                columns.Clear();
+            }
+
+            return columns;
+        }
+
+        /// <summary>
+        /// Print a line of data
+        /// </summary>
+        /// <param name="addNewline">Add after line was printed a new line</param>
+        /// <param name="columnData">Data to print.</param>
+        public void Print(bool addNewline, params string[] columnData)
+        {
+            Print(columnData, false);
+            if(addNewline)
+            {
+                Console.WriteLine();
+            }
+        }
+
+        /// <summary>
+        /// Print column titles to console
+        /// </summary>
+        /// <param name="bPrintNewLine">By default a new line is printed after headers were printed.</param>
+        public void PrintHeader(bool bPrintNewLine=true)
+        {
+            string[] headers = Columns.Select(x => x.Enabled ? x.Title : null).ToArray();
+            Print(headers, true);
+            if( bPrintNewLine )
+            {
+                Console.WriteLine();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="columnData"></param>
+        /// <param name="isHeader"></param>
+        void Print(string[] columnData, bool isHeader)
+        {
+            int lineNo = 0;
+            while (true)
+            {
+                List<KeyValuePair<string, ColumnDefinition>> columns = GetCombinedFormattedLine(lineNo, isHeader, columnData.ToArray());
+                
+
+                if (columns.Count  == 0 )
+                {
+                    break;
+                }
+
+                if (lineNo > 0)
+                {
+                    Console.WriteLine();
+                }
+
+                foreach (var col in columns)
+                {
+                    Printer(col.Key, col.Value.Color);
+                }
+                lineNo++;
+            }
+        }
+
+        string GetLine(ColumnDefinition column, string str, int lineNo, bool isHeader)
+        {
+            if (!column.Enabled)
+            {
+                return null;
+            }
+
+            if( String.IsNullOrEmpty(str) )
+            {
+                return "";
+            }
+
+            string line = (lineNo == 0 && column.DataWidth == 0) ? str : "";
+            if (column.DataWidth > 0)
+            {
+                int startIdx = lineNo * column.DataWidth;
+                int len = startIdx + column.DataWidth <= str.Length ? column.DataWidth : str.Length - startIdx;
+                line = startIdx >= str.Length ? "" : str.Substring(startIdx, len);
+            }
+            return line;
+        }
+    }
+}

--- a/ETWAnalyzer/Properties/AssemblyInfo.cs
+++ b/ETWAnalyzer/Properties/AssemblyInfo.cs
@@ -42,4 +42,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.9")]
+[assembly: AssemblyFileVersion("3.0.0.10")]

--- a/ETWAnalyzer/TraceProcessorHelpers/TcpETWConstants.cs
+++ b/ETWAnalyzer/TraceProcessorHelpers/TcpETWConstants.cs
@@ -97,6 +97,11 @@ namespace ETWAnalyzer.TraceProcessorHelpers
         public const int TcpAcceptListenerComplete = 1017;
 
         /// <summary>
+        /// Fields: LocalAddress:Binary RemoteAddress:Binary  Status:UInt32  ProcessId:UInt32  Compartment:UInt32  Tcb:Pointer 
+        /// </summary>
+        public const int TcpDisconnectTcbRtoTimeout = 1046;
+
+        /// <summary>
         /// Transfer Control block
         /// </summary>
         public const string TcbField = "Tcb";

--- a/ETWAnalyzer_uTest/EventDump/DumpBaseTests.cs
+++ b/ETWAnalyzer_uTest/EventDump/DumpBaseTests.cs
@@ -67,10 +67,10 @@ namespace ETWAnalyzer_uTest.EventDump
 
             var lTime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2000, 1, 1, 1, 0, 0) - utcOffset, TimeZoneInfo.Local);
 
-            Assert.Equal(lTime.ToString(DumpBase.DateTimeFormat), hereDateTime);
+            Assert.Equal(lTime.ToString(DumpBase.DateTimeFormat3), hereDateTime);
 
             string hereTime = dmp.GetDateTimeString(time, sessionStart, TimeFormats.HereTime);
-            Assert.Equal(lTime.ToString(DumpBase.TimeFormat), hereTime);
+            Assert.Equal(lTime.ToString(DumpBase.TimeFormat3), hereTime);
         }
 
         [Fact]

--- a/ETWAnalyzer_uTest/EventDump/DumpProcessesTests.cs
+++ b/ETWAnalyzer_uTest/EventDump/DumpProcessesTests.cs
@@ -158,8 +158,10 @@ namespace ETWAnalyzer_uTest.EventDump
             testOutput.Flush();
             string[] expectedOutput = new string[]
             {
+                "Proces Start T Stop T Duration   Return  Parent         Process Command Line",
+                "sId    ime     ime               Code                   ",
                 "1/1/2000 12:00:00 AM   test ",
-                "PID: 5001   Start:  Stop:  Duration:  RCode:  Parent:  5000  ImmortalChild.exe "
+                "  5001                                     Parent: 5000 ImmortalChild.exe ImmortalChild.exe"
             };
 
             var lines = testOutput.GetSingleLines();
@@ -446,13 +448,15 @@ namespace ETWAnalyzer_uTest.EventDump
 
             string[] expectedOutput = new string[]
             {
-                "1/1/0001 12:00:00 AM   File3 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000 Duration:  RCode:  Parent:    11  Session:  1 User1      " ,
-                "1/1/0001 12:00:00 AM   File2 " ,
-                "PID: 999    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000 Duration:  RCode:  Parent:     1  Session:  6 UserAdmin  " ,
-                "1/1/0001 12:00:00 AM   File1 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000 Duration:  RCode:  Parent:    11  Session:  1 UserAdmin  " ,
-                "PID: 666    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000 Duration:  RCode:  Parent:     1  Session:  8 User100    ",
+                "Proces Start Time                     Stop Time                     Duration   Return  Sess User      Parent         Process Command Line",
+                "sId                                                                            Code    ion                           ",
+                "1/1/0001 12:00:00 AM   File3 ",
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000                       1     User1 Parent:     11  ",
+                "1/1/0001 12:00:00 AM   File2 ",
+                "   999 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000                       6 UserAdmin Parent:      1  ",
+                "1/1/0001 12:00:00 AM   File1 ",
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000                       1 UserAdmin Parent:     11  ",
+                "   666 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000                       8   User100 Parent:      1  ",
                 "FileTotals: 2 Processes, 0 new, 2 exited, 0 permanent in 2 sessions of 2 users.",
                 "Totals: 4 Processes, 1 new, 3 exited, 1 permanent in 3 sessions of 3 users."
             };
@@ -483,20 +487,20 @@ namespace ETWAnalyzer_uTest.EventDump
                 ShowTotal = ETWAnalyzer.Commands.DumpCommand.TotalModes.File,
                 SortOrder = ETWAnalyzer.Commands.DumpCommand.SortOrders.Session,
             };
-
             dumper.Print(data);
-
             testOutput.Flush();
 
             string[] expectedOutput = new string[]
             {
-                "1/1/0001 12:00:00 AM   File3 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000 Duration:  RCode:  Parent:    11  Session:  1 User1      " ,
-                "1/1/0001 12:00:00 AM   File2 " ,
-                "PID: 999    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000 Duration:  RCode:  Parent:     1  Session:  6 UserAdmin  " ,
-                "1/1/0001 12:00:00 AM   File1 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000 Duration:  RCode:  Parent:    11  Session:  1 UserAdmin  " ,
-                "PID: 666    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000 Duration:  RCode:  Parent:     1  Session:  8 User100    ",
+                "Proces Start Time                     Stop Time                     Duration   Return  Sess User      Parent         Process Command Line",
+                "sId                                                                            Code    ion                           ",
+                "1/1/0001 12:00:00 AM   File3 ",
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000                       1     User1 Parent:     11  ",
+                "1/1/0001 12:00:00 AM   File2 ",
+                "   999 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000                       6 UserAdmin Parent:      1  ",
+                "1/1/0001 12:00:00 AM   File1 ",
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000                       1 UserAdmin Parent:     11  ",
+                "   666 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000                       8   User100 Parent:      1  ",
                 "FileTotals: 2 Processes, 0 new, 2 exited, 0 permanent in 2 sessions of 2 users."
             };
 
@@ -534,13 +538,15 @@ namespace ETWAnalyzer_uTest.EventDump
 
             string[] expectedOutput = new string[]
             {
+                "Proces Start Time                     Stop Time                     Duration   Return  Sess User      Parent         Process Command Line",
+                "sId                                                                            Code    ion                           ",
                 "1/1/0001 12:00:00 AM   File3 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000 Duration:  RCode:  Parent:    11  Session:  1 User1      " ,
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:10.000                       1     User1 Parent:     11  " ,
                 "1/1/0001 12:00:00 AM   File2 " ,
-                "PID: 999    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000 Duration:  RCode:  Parent:     1  Session:  6 UserAdmin  " ,
+                "   999 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:40.000                       6 UserAdmin Parent:      1  " ,
                 "1/1/0001 12:00:00 AM   File1 " ,
-                "PID: 111    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000 Duration:  RCode:  Parent:    11  Session:  1 UserAdmin  " ,
-                "PID: 666    Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000 Duration:  RCode:  Parent:     1  Session:  8 User100    "
+                "   111 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:01:00.000                       1 UserAdmin Parent:     11  " ,
+                "   666 Start: 2000-01-01 10:00:00.000 Stop: 2000-01-01 10:00:05.000                       8   User100 Parent:      1  "
             };
 
             var lines = testOutput.GetSingleLines();

--- a/ETWAnalyzer_uTest/EventDump/DumpProcessesTests.cs
+++ b/ETWAnalyzer_uTest/EventDump/DumpProcessesTests.cs
@@ -161,7 +161,7 @@ namespace ETWAnalyzer_uTest.EventDump
                 "Proces Start T Stop T Duration   Return  Parent         Process Command Line",
                 "sId    ime     ime               Code                   ",
                 "1/1/2000 12:00:00 AM   test ",
-                "  5001                                     Parent: 5000 ImmortalChild.exe ImmortalChild.exe"
+                "  5001                                   Parent:   5000 ImmortalChild.exe ImmortalChild.exe"
             };
 
             var lines = testOutput.GetSingleLines();

--- a/ETWAnalyzer_uTest/Extract/TcpExtractorTests.cs
+++ b/ETWAnalyzer_uTest/Extract/TcpExtractorTests.cs
@@ -173,19 +173,19 @@ namespace ETWAnalyzer_uTest.Extract
             var tcpData = iExtract.Network.TcpData;
 
             Assert.Single(tcpData.Connections);
-            Assert.Equal(2, tcpData.Retransmissions.Count);
+            Assert.Equal(3, tcpData.Retransmissions.Count);
 
             var retrans0 = tcpData.Retransmissions[0];
             Assert.Equal(100, retrans0.NumBytes);
             Assert.Equal((uint)SequenceNr.S_2000, retrans0.SequenceNumber);
-            Assert.Equal((long)Time.T0_4, retrans0.RetransmitTime.Ticks);
+            Assert.Equal((long)Time.T0_3, retrans0.RetransmitTime.Ticks);
             Assert.Equal((long)Time.T0_3, retrans0.SendTime.Ticks);
 
             var retrans1 = tcpData.Retransmissions[1];
             Assert.Equal(100, retrans1.NumBytes);
             Assert.Equal((uint)SequenceNr.S_2000, retrans1.SequenceNumber);
-            Assert.Equal((long)Time.T0_5, retrans1.RetransmitTime.Ticks);
-            Assert.Equal((long)Time.T0_3, retrans1.SendTime.Ticks);
+            Assert.Equal((long)Time.T0_4, retrans1.RetransmitTime.Ticks);
+            Assert.Equal((long)Time.T0_4, retrans1.SendTime.Ticks);
         }
 
 
@@ -318,7 +318,7 @@ namespace ETWAnalyzer_uTest.Extract
             Assert.Equal((uint) SequenceNr.S_3000, retrans2.SequenceNumber);
             Assert.Equal(600, retrans2.NumBytes);
             Assert.Equal((long) Time.T2_8, retrans2.RetransmitTime.Ticks);
-            Assert.Equal((long) Time.T2_5, retrans2.SendTime.Ticks);
+            Assert.Equal((long) Time.T2_8, retrans2.SendTime.Ticks);
         }
 
 

--- a/ETWAnalyzer_uTest/Infrastructure/MultilineFormatterTests.cs
+++ b/ETWAnalyzer_uTest/Infrastructure/MultilineFormatterTests.cs
@@ -235,5 +235,62 @@ namespace ETWAnalyzer_uTest.Infrastructure
 
 
         }
+
+
+        [Fact]
+        public void CanFormat_PrefixedData()
+        {
+            using var testOutput = new ExceptionalPrinter(myWriter, true);
+
+            MultiLineFormatter formatter = new(
+               new()
+               {
+                   Enabled = true,
+                   Title = "Header1",
+                   Prefix = "",
+                   DataWidth = 5,
+               },
+               new()
+               {
+                   Enabled = true,
+                   Title = "Header2",
+                   Prefix = "Pref2: ",
+                   DataWidth = 5,
+               }
+            );
+
+            string[] colData = new string[] { "Data1", "Data2" };
+
+            /*
+    Heade Heade 
+    r1    r2    
+    Data1 Pref2 
+          : Dat 
+             a2 
+             */
+
+            formatter.PrintHeader();
+            formatter.Print(true, colData);
+
+            formatter.Printer = ColumnPrinter;
+            Columns.Clear();
+
+            formatter.PrintHeader();
+            Assert.Equal(4, Columns.Count);
+            Assert.Equal("Heade ", Columns[0]);
+            Assert.Equal("r1    ", Columns[2]);
+            Assert.Equal("Heade ", Columns[1]);
+            Assert.Equal("r2    ", Columns[3]);
+
+            Columns.Clear();
+            formatter.Print(true, colData);
+            Assert.Equal(6, Columns.Count);
+            Assert.Equal("Data1 ", Columns[0]);
+            Assert.Equal("      ", Columns[2]);
+            Assert.Equal("      ", Columns[4]);
+            Assert.Equal("Pref2 ", Columns[1]);
+            Assert.Equal(": Dat ", Columns[3]);
+            Assert.Equal("   a2 ", Columns[5]);
+        }
     }
 }

--- a/ETWAnalyzer_uTest/Infrastructure/MultilineFormatterTests.cs
+++ b/ETWAnalyzer_uTest/Infrastructure/MultilineFormatterTests.cs
@@ -1,0 +1,239 @@
+﻿using ETWAnalyzer.Infrastructure;
+using ETWAnalyzer_uTest.TestInfrastructure;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ETWAnalyzer_uTest.Infrastructure
+{
+    public class MultilineFormatterTests
+    {
+        private ITestOutputHelper myWriter;
+        public MultilineFormatterTests(ITestOutputHelper myWriter)
+        {
+            this.myWriter = myWriter;
+        }
+
+        List<string> Columns { get; set; } = new();
+
+        private void ColumnPrinter(string str, ConsoleColor? color)
+        {
+            Columns.Add(str);
+        }
+
+        [Fact]
+        public void CanFormat_ShortHeader()
+        {
+            MultiLineFormatter formatter = new(
+            new ColumnDefinition()
+            {
+                Enabled = true,
+                Title = "1234",
+                DataWidth = 5,
+            })
+            {
+                Printer = ColumnPrinter
+            };
+            Columns.Clear();
+
+            formatter.PrintHeader();
+
+            Assert.Single(Columns);
+            Assert.Equal("1234  ", Columns[0]);
+
+            Columns.Clear();
+            formatter.Columns[0].Enabled = false;
+            formatter.PrintHeader();
+            Assert.Empty(Columns);
+        }
+
+        [Fact]
+        public void CanFormat_EqualHeader()
+        {
+            MultiLineFormatter formatter = new(
+            new ColumnDefinition()
+            {
+                Enabled = true,
+                Title = "12345",
+                DataWidth = 5,  // column width includes space
+            })
+            {
+                Printer = ColumnPrinter
+            };
+            Columns.Clear();
+
+            formatter.PrintHeader();
+            Assert.Single(Columns);
+            Assert.Equal("12345 ", Columns[0]);
+
+            Columns.Clear();
+
+            formatter.Columns[0].Enabled = false;
+            formatter.PrintHeader();
+            Assert.Empty(Columns);
+        }
+
+        [Fact]
+        public void CanFormat_LargerHeader()
+        {
+            MultiLineFormatter formatter = new(
+            new ColumnDefinition()
+            {
+                Enabled = true,
+                Title = "123456",
+                DataWidth = 5,
+            })
+            {
+                Printer = ColumnPrinter
+            };
+
+            Columns.Clear();
+            formatter.PrintHeader();
+
+            Assert.Equal(2, Columns.Count);
+            Assert.Equal("12345 ", Columns[0]);
+            Assert.Equal("6     ", Columns[1]);
+        }
+
+        [Fact]
+        public void Can_Format_LargeChainedHeader()
+        {
+            MultiLineFormatter formatter = new(
+                new()
+                {
+                    Enabled = true,
+                    Title = "123456",
+                    DataWidth = 5,
+                },
+                new()
+                {
+                    Enabled = true,
+                    Title = "321",
+                    DataWidth = 5,
+                },
+                new()
+                {
+                Enabled = true,
+                Title = "21",
+                DataWidth = 5,
+           })
+            {
+                Printer = ColumnPrinter
+            };
+
+            Columns.Clear();
+            formatter.PrintHeader();
+
+            Assert.Equal(6, Columns.Count);
+
+            Assert.Equal("12345 ", Columns[0]);
+            Assert.Equal("6     ", Columns[3]);
+            Assert.Equal("321   ", Columns[1]);
+            Assert.Equal("      ", Columns[4]);
+            Assert.Equal("21    ", Columns[2]);
+            Assert.Equal("      ", Columns[5]);
+        }
+
+
+        [Fact]
+        public void Can_Format_LargeChainedHeader_WithDisabled()
+        {
+            MultiLineFormatter formatter = new(
+                new()
+                {
+                    Enabled = false,
+                    Title = "123456",
+                    DataWidth = 5,
+                },
+                new()
+                {
+                    Enabled = true,
+                    Title = "321",
+                    DataWidth = 5,
+                },
+                new()
+                {
+                    Enabled = true,
+                    Title = "21",
+                    DataWidth = 5,
+                })
+            {
+                Printer = ColumnPrinter
+            };
+
+            Columns.Clear();
+            formatter.PrintHeader();
+
+            Assert.Equal(2, Columns.Count);
+            Assert.Equal("321   ", Columns[0]);
+            Assert.Equal("21    ", Columns[1]);
+        }
+
+
+        [Fact]
+        public void Can_FormatChained_Data()
+        {
+            using var testOutput = new ExceptionalPrinter(myWriter, true);
+
+            MultiLineFormatter formatter = new(
+                new()
+                {
+                    Enabled = true,
+                    Title = "Header1",
+                    DataWidth = 8,
+                },
+                new()
+                {
+                    Enabled = true,
+                    Title = "Header2",
+                    DataWidth = 9,
+                },
+                new()
+                {
+                    Enabled = true,
+                    Title = "Header3",
+                    DataWidth = 7,
+                    Color = ConsoleColor.Red,
+                }
+             );
+
+            formatter.PrintHeader();
+            Console.WriteLine();
+
+            string[] columnData = new string[] { "ColData1", "ColData2", "ColData3" };
+
+            formatter.Print(false, columnData);
+
+            formatter.Printer = ColumnPrinter;
+            Columns.Clear();
+
+            /*
+ Header1 Header2  Header 
+                  3      
+ ColData ColData2 ColDat 
+       1              a3 
+             */
+
+            formatter.PrintHeader();
+            Assert.Equal(3, Columns.Count);
+
+            Assert.Equal("Header1  ", Columns[0]);
+            Assert.Equal("Header2   ", Columns[1]);
+            Assert.Equal("Header3 ", Columns[2]);
+
+            Columns.Clear();
+            formatter.Print(false, columnData); ;
+            Assert.Equal(6, Columns.Count);
+
+            Assert.Equal("ColData1 ", Columns[0]);
+            Assert.Equal("         ", Columns[3]);
+            Assert.Equal(" ColData2 ", Columns[1]);
+            Assert.Equal("          ", Columns[4]);
+            Assert.Equal("ColData ", Columns[2]);
+            Assert.Equal("      3 ", Columns[5]);
+
+
+        }
+    }
+}


### PR DESCRIPTION
- Added `-TimeDigits` flag to configure with how many digits time is displayed (0-6)
- Added to `-Console` option to pass input files on input command line which are directly loaded
- TCP reset time is now also extracted if socket is closed because other side did not respond.
- `Dump TCP` columns are configurable with `-column` ... option
- `Dump Proces`s columns are configurable  with `-column` ... option


