### PR TITLE
Fix for issue #92.

### DIFF
--- a/ETWAnalyzer/ETWAnalyzer.csproj
+++ b/ETWAnalyzer/ETWAnalyzer.csproj
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Siemens-Healthineers/ETWAnalyzer</PackageProjectUrl>
     <PackageReadmeFile>ProgramaticAccess.md</PackageReadmeFile>
-    <Version>3.0.0.10</Version>
+    <Version>3.0.0.11</Version>
     <Platforms>x64</Platforms>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>

--- a/ETWAnalyzer/Extractors/CPU/CpuFrequencyExtractor.cs
+++ b/ETWAnalyzer/Extractors/CPU/CpuFrequencyExtractor.cs
@@ -37,9 +37,16 @@ namespace ETWAnalyzer.Extractors.CPU
                             break;
                         }
                     }
-                    catch(ArgumentOutOfRangeException)
+                    catch (ArgumentOutOfRangeException)
                     {
                         Console.WriteLine($"Warning: File {results.SourceETLFileName} contains CPU frequency ETW data, but AverageFrequency is not accessible. This happens when the CaptureState for the Microsoft-Windows-Kernel-Processor-Power provider is missing.");
+                        break;
+                    }
+                    catch (InvalidTraceDataException ex)
+                    {
+                        string msg  = $"File {results.SourceETLFileName} contains CPU frequency ETW data, but AverageFrequency is not accessible, because of a CPU count mismatch: ";
+                        Console.WriteLine("Warning: " + msg + ex.Message);
+                        Logger.Warn(msg + ex);
                         break;
                     }
 

--- a/ETWAnalyzer/Properties/AssemblyInfo.cs
+++ b/ETWAnalyzer/Properties/AssemblyInfo.cs
@@ -42,4 +42,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.10")]
+[assembly: AssemblyFileVersion("3.0.0.11")]


### PR DESCRIPTION
Microsoft.Windows.EventTracing.InvalidTraceDataException: Two info sources disagree on the number of processors.
   at Microsoft.Windows.EventTracing.Metadata.SystemMetadata.get_Processors()
   at Microsoft.Windows.EventTracing.Power.ProcessorFrequencyObjectContext.GetAverageFrequency(ProcessorFrequencyIntervalFlyweight flyweight)
   at Microsoft.Windows.EventTracing.Power.ProcessorFrequencyInterval.get_AverageFrequency()
   at ETWAnalyzer.Extractors.CPU.CpuFrequencyExtractor.Extract(ITraceProcessor processor, ETWExtract results) in C:\Builds\ETWAnalyzer\ETWAnalyzer\Extractors\CPU\CpuFrequencyExtractor.cs:line 34