### PR TITLE
-Dump ObjectRef Time Fix

### DIFF
--- a/ETWAnalyzer/EventDump/DumpObjectRef.cs
+++ b/ETWAnalyzer/EventDump/DumpObjectRef.cs
@@ -799,9 +799,9 @@ namespace ETWAnalyzer.EventDump
                 var child = extract.Processes.OrderBy(x => x.StartTime).Where(x => x.ParentPid == parent.ProcessID && 
                                                                               x.StartTime > parent.StartTime && 
                                                                               x.StartTime < parent.EndTime &&
-                                                                              x.StartTime > handleduplicate.GetTime(extract.SessionStart)
+                                                                              x.StartTime > handleduplicate.GetTime(extract.BootTime)
                                                                               ).FirstOrDefault();
-                if( child?.StartTime > handleduplicate.GetTime(extract.SessionStart))
+                if( child?.StartTime > handleduplicate.GetTime(extract.BootTime))
                 {
                     lret = child;
                 }
@@ -921,7 +921,7 @@ namespace ETWAnalyzer.EventDump
 
         void PrintEventHeader(IStackEventBase ev, IETWExtract resolver, string name, string beforeProc = null)
         {
-            string timeStr = base.GetTimeString(ev.GetTime(resolver.SessionStart), resolver.SessionStart, this.TimeFormatOption);
+            string timeStr = base.GetTimeString(ev.GetTime(resolver.BootTime), resolver.SessionStart, this.TimeFormatOption);
             ColorConsole.WriteEmbeddedColorLine($"\t{timeStr} [magenta]{GetProcessId(ev.ProcessIdx, resolver),5}[/magenta]/{ev.ThreadId,-5} {name} {beforeProc}[magenta]{GetProcessAndStartStopTags(ev.ProcessIdx, resolver,false)}[/magenta] ", null, true);
         }
 

--- a/ETWAnalyzer/Extract/Common/StackEventBase.cs
+++ b/ETWAnalyzer/Extract/Common/StackEventBase.cs
@@ -28,16 +28,16 @@ namespace ETWAnalyzer.Extract.Common
         int ThreadId { get; }
 
         /// <summary>
-        /// Event time
+        /// Event time  since boot in nanoseconds.
         /// </summary>
         long TimeNs { get; }
 
         /// <summary>
         /// Get local time as DateTimeOffset
         /// </summary>
-        /// <param name="traceStart">Trace start time</param>
+        /// <param name="bootTime">Trace start time</param>
         /// <returns>local time</returns>
-        DateTimeOffset GetTime(DateTimeOffset traceStart);
+        DateTimeOffset GetTime(DateTimeOffset bootTime);
 
     }
 
@@ -47,15 +47,15 @@ namespace ETWAnalyzer.Extract.Common
     public class StackEventBase : IStackEventBase
     {
         /// <summary>
-        /// Time
+        /// Get time from time since boot and TimeNs
         /// </summary>
-        public DateTimeOffset GetTime(DateTimeOffset traceStart)
+        public DateTimeOffset GetTime(DateTimeOffset bootTime)
         {
-            return traceStart.AddTicks(TimeNs / 100);
+            return new DateTimeOffset(TimeNs/100+bootTime.Ticks + bootTime.Offset.Ticks, bootTime.Offset);
         }
 
         /// <summary>
-        /// Time since trace start in nanoseconds.
+        /// Time since boot in nanoseconds.
         /// </summary>
         public long TimeNs { get; set; }
 


### PR DESCRIPTION
When printing local time in ETWAnalyzer for ObjectRef/FileMap events time was wrong.
ETW events are timestamped in ns with time since boot which is now properly calculcated.