### PR TITLE
Add ETWAnalyzer.McpServer.exe

### DIFF
--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -42,13 +42,20 @@ jobs:
         - name: Build Release
           run: ${{ github.workspace }}\ETWAnalyzer\MakeRelease.cmd
             
-        - name: Upload .NET 10 Binaries
+        - name: Upload .NET 10 Binaries Not Self Contained  
           uses: actions/upload-artifact@v7
           with:
-            name: Net10Binaries
-            path: ${{ github.workspace }}/bin/Release/ETWAnalyzer_Net10.zip
+            name: ETWAnalyzerMCP
+            path: ${{ github.workspace }}/bin/Release/Net10-NotSelfContained
             retention-days: 90
 
+        - name: Upload MCP Server and ETWAnalyzer Self Contained
+          uses: actions/upload-artifact@v7
+          with:
+            name: ETWAnalyzerMCP_SelfContained
+            path: ${{ github.workspace }}/bin/Release/publishMCPNet10
+            retention-days: 90
+            
         - name: Upload Nuget Package
           uses: actions/upload-artifact@v7
           with:
@@ -60,5 +67,5 @@ jobs:
           uses: actions/upload-artifact@v7
           with:
             name: Samples_Binaries_Zip
-            path: ${{ github.workspace }}/bin/Release/Samples_Binaries.zip
+            path: ${{ github.workspace }}/Samples/bin/x64/Release
             retention-days: 90

--- a/ETWAnalyzer.McpServer/ConsoleOutputCapture.cs
+++ b/ETWAnalyzer.McpServer/ConsoleOutputCapture.cs
@@ -1,0 +1,36 @@
+//// SPDX-FileCopyrightText:  © 2026 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+namespace ETWAnalyzer.McpServer
+{
+    /// <summary>
+    /// Captures console output during command execution by temporarily redirecting Console.Out.
+    /// </summary>
+    internal sealed class ConsoleOutputCapture : IDisposable
+    {
+        private readonly TextWriter myOriginalOut;
+        private readonly StringWriter myCapture;
+
+        public ConsoleOutputCapture()
+        {
+            myOriginalOut = Console.Out;
+            myCapture = new StringWriter();
+            Console.SetOut(myCapture);
+        }
+
+        /// <summary>
+        /// Get the captured output and restore the original console.
+        /// </summary>
+        public string GetOutput()
+        {
+            Console.SetOut(myOriginalOut);
+            return myCapture.ToString();
+        }
+
+        public void Dispose()
+        {
+            Console.SetOut(myOriginalOut);
+            myCapture.Dispose();
+        }
+    }
+}

--- a/ETWAnalyzer.McpServer/ETWAnalyzer.McpServer.csproj
+++ b/ETWAnalyzer.McpServer/ETWAnalyzer.McpServer.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	<OutputType>Exe</OutputType>
+	<TargetFramework>net10.0-windows</TargetFramework>
+	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+	<SelfContained>false</SelfContained>
+	<RootNamespace>ETWAnalyzer.McpServer</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<OutputPath>..\bin\Release\</OutputPath>
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<OutputPath>..\bin\Release\</OutputPath>
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>..\bin\Debug\</OutputPath>
+		<DebugType>full</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<OutputPath>..\bin\Debug\</OutputPath>
+		<DebugType>full</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
+		<PlatformTarget>x64</PlatformTarget>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Platform)'=='x64'">
+		<PlatformTarget>x64</PlatformTarget>
+	</PropertyGroup>	
+	
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\ETWAnalyzer\ETWAnalyzer.csproj" />
+	<ProjectReference Include="..\ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+	<Content Include="ETWAnalyzerSkill\Skill.md">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<pack>false</pack>
+	</Content>
+  </ItemGroup>
+	
+</Project>

--- a/ETWAnalyzer.McpServer/ETWAnalyzerSkill/Skill.md
+++ b/ETWAnalyzer.McpServer/ETWAnalyzerSkill/Skill.md
@@ -1,0 +1,635 @@
+---
+name: ETWAnalyzer-mcp
+description: This skill should be used to interact with the ETWAnalyzer MCP (Model Context Protocol) server. The MCP server provides tools to analyze ETW (Event Tracing for Windows) performance traces without needing to manually run command-line tools.
+version: 0.1.0
+---
+
+# ETWAnalyzer MCP Server - Agent Documentation
+
+This document describes how to use the ETWAnalyzer MCP (Model Context Protocol). The MCP server provides tools to analyze ETW (Event Tracing for Windows) performance traces without needing to manually run command-line tools.
+
+## Overview
+
+The ETWAnalyzer MCP server exposes ETWAnalyzer functionality as callable tools that can:
+- Load and manage ETW trace files (.json7z/.json extracts)
+- Query CPU, memory, disk, network, exception, and other performance data
+- Analyze cpu issues, memory and handle leaks, thread pool starvation, and other runtime issues
+- All without switching to command-line tools manually
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Session Management](#session-management)
+- [Available Tools](#available-tools)
+- [Common Patterns](#common-patterns)
+- [Real-World Examples](#real-world-examples)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+1. **Extracted ETW data**: ETWAnalyzer works with extracted JSON files (.json7z or .json), not raw .etl files
+2. **File path**: Know the full path to your extracted trace file(s)
+
+### Basic Workflow
+
+```
+1. Load trace file(s)    → etw_load
+2. Query data            → etw_dump_* (cpu, memory, process, etc.)
+3. Analyze results       → Interpret output
+4. Optional: Unload      → etw_unload
+```
+
+---
+
+## Session Management
+
+### Loading Files
+
+**Load a single extracted trace file:**
+```
+User: "E:\Unsynced\Carbon\UserHandleLeak\Extract\ContainerStart.json7z"
+```
+
+The agent will call `etw_load` automatically. Files remain loaded for the entire session.
+
+**Load multiple files or directories:**
+```
+etw_load:
+  filePaths: "C:\Extract\Test1.json7z,C:\Extract\Test2.json7z"
+  
+etw_load:
+  filePaths: "C:\Extract"
+  recursive: true
+```
+
+**Add files to existing session (don't replace):**
+```
+etw_load:
+  filePaths: "C:\Extract\NewTrace.json7z"
+  keepOldFiles: true
+```
+
+### Listing Loaded Files
+
+**Check what's currently loaded:**
+```
+User: "What files are loaded?"
+→ Agent calls: etw_list
+```
+
+### Unloading Files
+
+**Unload all files:**
+```
+etw_unload
+```
+
+**Unload specific files:**
+```
+etw_unload:
+  filePaths: "C:\Extract\Test1.json7z"
+```
+
+---
+
+## Available Tools
+
+### Core Analysis Tools
+
+| Tool | Purpose | Key Arguments |
+|------|---------|---------------|
+| `etw_dump_cpu` | CPU consumption by process/method | `-topN`, `-topNMethods`, `-Methods`, `-StackTags`, `-ProcessName` |
+| `etw_dump_memory` | Memory usage (WorkingSet, Commit) | `-topN`, `-ProcessName`, `-SortBy`, `-GlobalDiffMB` |
+| `etw_dump_process` | Process info (start/stop, command line, return code) | `-ProcessName`, `-NewProcess`, `-SortBy`, `-Crash` |
+| `etw_dump_exception` | .NET exceptions with stacks | `-Type`, `-ShowStack`, `-ProcessName` |
+| `etw_dump_disk` | Disk I/O per directory/file/process | `-DirLevel`, `-ProcessName`, `-PerProcess`, `-MinMaxSize` |
+| `etw_dump_file` | File I/O operations (read/write/open/close) | `-DirLevel`, `-ProcessName`, `-PerProcess`, `-FileOperation`, `-fileName` |
+| `etw_dump_tcp` | TCP connection statistics | `-SortBy`, `-MinMaxRetransCount` |
+| `etw_dump_dns` | DNS query latency and results | `-DnsQueryFilter`, `-MinMaxTime` |
+| `etw_dump_stats` | Trace metadata (OS, CPU, duration, etc.) | `-Properties *` |
+| `etw_dump_version` | Module/DLL versions | `-dll`, `-ProcessName` |
+| `etw_dump_objectref` | Handle/object tracking (leaks) | `-Leak`, `-ShowStack`, `-ProcessName` |
+| `etw_dump_virtualalloc` | VirtualAlloc memory allocations | `-Details`, `-ShowStack`, `-TopNStacks` |
+| `etw_dump_threadpool` | .NET ThreadPool starvation events | `-ProcessName` |
+| `etw_dump_marker` | ETW marker events | `-MarkerFilter`, `-ZeroTime` |
+| `etw_dump_power` | Power profile settings | `-details`, `-Diff` |
+| `etw_dump_pmc` | Performance Monitoring Counters | `-pn` |
+| `etw_dump_lbr` | Last Branch Record CPU profiling | `-pn`, `-topnmethods`, `-showcaller` |
+
+### Getting Help
+
+**Get help for a specific command:**
+```
+etw_help:
+  command: "CPU"
+```
+
+---
+
+## Common Patterns
+
+### 1. Initial Trace Investigation
+
+**Load and get basic stats:**
+```
+etw_load → "E:\Traces\Issue.json7z"
+etw_dump_stats → arguments: "-Properties *"
+```
+
+**Find top CPU consumers:**
+```
+etw_dump_cpu:
+  arguments: "-topN 10"
+```
+
+**See process timeline:**
+```
+etw_dump_process:
+  arguments: "-ProcessFmt s -SortBy StartTime"
+```
+
+### 2. CPU Analysis
+
+**Top processes with method breakdown:**
+```
+etw_dump_cpu:
+  arguments: "-topN 5 -topNMethods 20"
+```
+
+**Analyze specific process with stacktags:**
+```
+etw_dump_cpu:
+  arguments: "-ProcessName *syngo.Viewing* -StackTags * -ShowTotal Process"
+```
+
+**Find methods consuming most CPU:**
+```
+etw_dump_cpu:
+  arguments: "-Methods * -topNMethods 50 -SortBy CPU"
+```
+
+**Show first/last occurrence of methods (for duration analysis):**
+```
+etw_dump_cpu:
+  arguments: "-ProcessName myapp.exe -Methods *Initialize* -fld s s"
+```
+
+**Include thread count and module info:**
+```
+etw_dump_cpu:
+  arguments: "-ProcessName myapp.exe -Methods * -ThreadCount -ShowModuleInfo"
+```
+
+**Filter by CPU time:**
+```
+etw_dump_cpu:
+  arguments: "-MinMaxCpuMs 100 -ProcessName myapp.exe"
+```
+
+### 3. Memory Analysis
+
+**Top memory consumers:**
+```
+etw_dump_memory:
+  arguments: "-topN 10 -SortBy Commit"
+```
+
+**Find memory leaks across multiple traces:**
+```
+etw_dump_memory:
+  arguments: "-GlobalDiffMB 500"
+```
+
+**Total machine memory:**
+```
+etw_dump_memory:
+  arguments: "-TotalMemory"
+```
+
+### 4. Process Analysis
+
+**Find crashed processes:**
+```
+etw_dump_process:
+  arguments: "-Crash"
+```
+
+**Show process tree:**
+```
+etw_dump_process:
+  arguments: "-SortBy Tree"
+```
+
+**New processes started during trace:**
+```
+etw_dump_process:
+  arguments: "-NewProcess 1"
+```
+
+**Filter by process name:**
+```
+etw_dump_process:
+  arguments: "-ProcessName *chrome*;!*chromers*"
+```
+
+### 5. Exception Analysis
+
+**All exceptions with stacks:**
+```
+etw_dump_exception:
+  arguments: "-ShowStack"
+```
+
+**Filter by exception type:**
+```
+etw_dump_exception:
+  arguments: "-Type *TimeoutException* -ShowStack"
+```
+
+### 6. Handle Leak Investigation
+
+**Find handle leaks:**
+```
+etw_dump_objectref:
+  arguments: "-Leak -ShowStack -ProcessName myapp.exe"
+```
+
+**Show top stack traces:**
+```
+etw_dump_virtualalloc:
+  arguments: "-Details -ShowStack -TopNStacks 10 -ProcessName myapp.exe"
+```
+
+### 7. Disk and File I/O
+
+**Disk I/O by directory:**
+```
+etw_dump_disk:
+  arguments: "-DirLevel 3 -PerProcess"
+```
+
+**File operations:**
+```
+etw_dump_file:
+  arguments: "-PerProcess -fileName E:\\Data\\*"
+```
+
+### 8. Network Analysis
+
+**TCP connections with retransmissions:**
+```
+etw_dump_tcp:
+  arguments: "-SortBy RetransmissionCount -MinMaxRetransCount 1"
+```
+
+**DNS queries taking too long:**
+```
+etw_dump_dns:
+  arguments: "-MinMaxTime 20ms"
+```
+
+### 9. Extended CPU Metrics
+
+**Show detailed CPU data with frequency and ready times:**
+```
+etw_dump_cpu:
+  arguments: "-topN 3 -topNMethods 10 -Details"
+```
+
+**Normalized CPU time (for frequency comparison):**
+```
+etw_dump_cpu:
+  arguments: "-topN 5 -Details -Normalize"
+```
+
+**Hide specific columns:**
+```
+etw_dump_cpu:
+  arguments: "-topN 5 -Details -NoFrequency -NoReady"
+```
+
+---
+
+## Real-World Examples
+
+### Example 1: Investigating UI Hang
+
+**Scenario:** Application UI becomes unresponsive for several seconds
+
+```
+1. Load trace
+   etw_load → "C:\Traces\UIHang.json7z"
+
+2. Check CPU during hang window
+   etw_dump_cpu → "-Methods * -MinMaxFirst 45 50 -topNMethods 30"
+   
+3. Look for long waits
+   etw_dump_cpu → "-SortBy Wait -topN 5 -topNMethods 50"
+   
+4. Check for exceptions
+   etw_dump_exception → "-ShowStack"
+```
+
+### Example 2: Memory Leak Detection
+
+**Scenario:** Process memory grows over time
+
+```
+1. Load multiple sequential traces
+   etw_load → "C:\Traces\LongRun" (directory with multiple files)
+   recursive: true
+   
+2. Find leaking processes
+   etw_dump_memory → "-GlobalDiffMB 100"
+   
+3. Investigate VirtualAlloc patterns
+   etw_dump_virtualalloc → "-ProcessName leaky.exe -Details -ShowStack -TopNStacks 20"
+   
+4. Check handle leaks
+   etw_dump_objectref → "-Leak -ProcessName leaky.exe -ShowStack"
+```
+
+### Example 3: Slow Startup Investigation
+
+**Scenario:** Application startup time has regressed
+
+```
+1. Load trace
+   etw_load → "C:\Traces\Startup.json7z"
+   
+2. See process start order
+   etw_dump_process → "-ProcessFmt s -SortBy StartTime"
+   
+3. Analyze startup CPU
+   etw_dump_cpu → "-ProcessName myapp.exe -Methods * -fld s s -SortBy First"
+   
+4. Check for file I/O delays
+   etw_dump_file → "-ProcessName myapp.exe -PerProcess"
+   
+5. Look for network delays
+   etw_dump_tcp → "-ProcessName myapp.exe"
+   etw_dump_dns → "-MinMaxTime 50ms"
+```
+
+### Example 4: Finding Virus Scanner Impact
+
+**Scenario:** Suspecting AV software slowing down operations
+
+```
+1. Load trace
+   etw_load → "C:\Traces\Performance.json7z"
+   
+2. Check for AV drivers
+   etw_dump_cpu → "-ShowModuleInfo Driver -topN 50"
+   
+3. Look for antivirus stacktaqs
+   etw_dump_cpu → "-StackTags *Virus*"
+   
+4. Check disk I/O patterns
+   etw_dump_disk → "-PerProcess"
+```
+
+### Example 5: Thread Pool Starvation
+
+**Scenario:** .NET application has delayed task execution
+
+```
+1. Load trace
+   etw_load → "C:\Traces\ThreadIssue.json7z"
+   
+2. Check for thread starvation events
+   etw_dump_threadpool → "-ProcessName myapp.exe"
+  
+3. Analyze wait times
+   etw_dump_cpu → "-ProcessName myapp.exe -SortBy Wait -topNMethods 150"
+```
+
+### Example 6: Comparing Performance Between Versions
+
+**Scenario:** Need to compare two builds
+
+```
+1. Load both traces
+   etw_load → "C:\Traces\Baseline.json7z"
+   etw_load → "C:\Traces\New.json7z" (keepOldFiles: true)
+   
+2. Compare CPU totals
+   etw_dump_cpu → "-ProcessName myapp.exe -ShowTotal Process"
+   
+3. Compare specific methods
+   etw_dump_cpu → "-Methods *Initialize* -ProcessName myapp.exe"
+   
+4. Compare memory usage
+   etw_dump_memory → "-ProcessName myapp.exe"
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**1. "No files loaded"**
+- Make sure to call `etw_load` before dump commands
+- Check file path is correct (use full absolute path)
+- Verify file extension is .json7z or .json
+
+**2. "No data found"**
+- The extractor may not have included this data type
+- Check what was extracted: `etw_dump_stats`
+- Re-extract with needed extractors (see ETWAnalyzer documentation)
+
+**3. Empty results**
+- Process name filter may be too restrictive
+- Try without filters first: `etw_dump_process` to see all processes
+- Use wildcards: `-ProcessName *partial*`
+
+**4. Too much output**
+- Use `-topN` to limit processes
+- Use `-topNMethods` to limit methods
+- Filter by CPU/time: `-MinMaxCpuMs 100`
+
+**5. Need more detail**
+- Add `-Details` for extended metrics
+- Use `-ShowStack` for exception/objectref
+- Use `-ShowModuleInfo` for version info
+- Use `-ThreadCount` for thread information
+
+### Filter Syntax
+
+ETWAnalyzer uses consistent filter syntax:
+
+- **Multiple filters:** Separate with `;`
+  - Example: `*chrome*;*firefox*`
+
+- **Exclusions:** Prefix with `!`
+  - Example: `*chrome*;!*chromers*`
+
+- **Wildcards:** 
+  - `*` matches zero or more characters
+  - `?` matches zero or one character
+
+- **Case-insensitive:** All filters are case-insensitive
+
+### Time Formats
+
+Many commands support `-TimeFmt` for time display:
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| `s` | Seconds since trace start | `45.123` |
+| `Local` | Local time with date | `2024-04-28 11:55:20.123` |
+| `LocalTime` | Local time without date | `11:55:20.123` |
+| `UTC` | UTC time with date | `2024-04-28 09:55:20.123` |
+| `UTCTime` | UTC time without date | `09:55:20.123` |
+
+### Process Filters
+
+`-NewProcess` values:
+
+| Value | Meaning |
+|-------|---------|
+| `0` | Processes running entire trace |
+| `1` | Processes started during trace |
+| `-1` | Processes exited during trace |
+| `2` | Started but not stopped |
+| `-2` | Stopped but not started |
+
+---
+
+## Advanced Features
+
+### StackTags
+
+StackTags group CPU consumption by semantic categories (e.g., .NET GC, JIT, WPF rendering, SQL queries).
+
+**View all stacktags:**
+```
+etw_dump_cpu:
+  arguments: "-StackTags * -ProcessName myapp.exe -ShowTotal Method"
+```
+
+**Filter specific categories:**
+```
+etw_dump_cpu:
+  arguments: "-StackTags *GC*;*JIT* -ShowTotal Process"
+```
+
+### Zero Time
+
+Shift time baseline for relative analysis:
+
+**Relative to first method occurrence:**
+```
+etw_dump_cpu:
+  arguments: "-Methods *Initialize* -ZeroTime First *OnClick* -fld s s"
+```
+
+**Relative to process start:**
+```
+etw_dump_cpu:
+  arguments: "-ZeroTime ProcessStart -ZeroProcessName myapp.exe -fld s s"
+```
+
+### Marker Events
+
+Correlate with custom ETW markers:
+
+```
+etw_dump_marker:
+  arguments: "-MarkerFilter *TestStart* -ZeroTime marker *TestStart*"
+```
+
+### CSV Export
+
+All dump commands support `-csv` for exporting to files. These can be examined further. 
+
+```
+etw_dump_cpu:
+  arguments: "-ProcessName myapp.exe -Methods * -csv C:\\Results\\cpu_data.csv"
+```
+
+---
+
+## Best Practices
+
+1. **Start broad, then narrow:**
+   - Begin with `-topN 10` to see big picture
+   - Drill down with `-ProcessName` filters
+   - Use `-Methods *pattern*` for specific investigations
+
+2. **Use appropriate metrics:**
+   - CPU analysis: Focus on `-topNMethods` and stacktags
+   - Memory leaks: Use `-GlobalDiffMB` across traces
+   - Hangs: Check `-SortBy Wait` and exception data
+
+3. **Leverage multiple data sources:**
+   - CPU + Exception + File I/O gives complete picture
+   - Process + Memory + ObjectRef for leak investigations
+   - TCP + DNS for network issues
+
+4. **Time correlation:**
+   - Use `-fld s s` to see when methods execute
+   - Use `-ProcessFmt s` to see process timelines
+   - Use `-ZeroTime` to align multiple traces
+
+5. **Documentation:**
+   - Use `etw_help` for command-specific details
+   - Check `etw_dump_stats` for trace metadata
+   - Verify data availability before deep analysis
+
+---
+
+## Useful Queries Quick Reference
+
+```bash
+# Quick overview
+etw_dump_stats → "-Properties *"
+etw_dump_process → "-SortBy StartTime"
+etw_dump_cpu → "-topN 10"
+
+# CPU deep dive
+etw_dump_cpu → "-ProcessName myapp* -StackTags * -ShowTotal Method -topNMethods 50"
+
+# Memory investigation
+etw_dump_memory → "-topN 10 -Details"
+etw_dump_virtualalloc → "-Details -ShowStack -TopNStacks 10"
+
+# Exception analysis
+etw_dump_exception → "-Type * -ShowStack"
+
+# Network issues
+etw_dump_tcp → "-SortBy RetransmissionCount"
+etw_dump_dns → "-MinMaxTime 100ms"
+
+# File I/O
+etw_dump_file → "-PerProcess -fileName C:\\*"
+etw_dump_disk → "-DirLevel 3"
+
+# Handle leaks
+etw_dump_objectref → "-Leak -ShowStack"
+
+# Process crashes
+etw_dump_process → "-Crash"
+```
+
+---
+
+## Additional Resources
+
+- **ETWAnalyzer GitHub:** https://github.com/Alois-xx/ETWAnalyzer
+- **WPA (Windows Performance Analyzer):** For visual correlation with trace data
+- **ETW Recording:** Use ETWController or wpr.exe to capture traces
+- **Symbol Servers:** Configure `-SymServer` during extraction for full method names
+
+---
+
+## Version Information
+
+This documentation is based on ETWAnalyzer version 6.x+ with MCP server integration.
+
+For questions or issues with the MCP server, contact the ETWAnalyzer team or file an issue on the GitHub repository.

--- a/ETWAnalyzer.McpServer/EtwSession.cs
+++ b/ETWAnalyzer.McpServer/EtwSession.cs
@@ -1,0 +1,201 @@
+//// SPDX-FileCopyrightText:  © 2026 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.Extract;
+using ETWAnalyzer.Infrastructure;
+using ETWAnalyzer.ProcessTools;
+
+namespace ETWAnalyzer.McpServer
+{
+    /// <summary>
+    /// Stateful session that mirrors the ConsoleCommand pattern.
+    /// Files are loaded once and reused across multiple MCP tool calls.
+    /// </summary>
+    internal class EtwSession
+    {
+        private static readonly object myLock = new();
+        private static EtwSession? myInstance;
+
+        /// <summary>
+        /// Singleton instance shared across all MCP tool calls.
+        /// </summary>
+        public static EtwSession Instance
+        {
+            get
+            {
+                if (myInstance == null)
+                {
+                    lock (myLock)
+                    {
+                        myInstance ??= new EtwSession();
+                    }
+                }
+                return myInstance;
+            }
+        }
+
+        /// <summary>
+        /// Currently loaded files, same pattern as ConsoleCommand.myInputFiles
+        /// </summary>
+        private Lazy<SingleTest>[]? myInputFiles;
+
+        /// <summary>
+        /// Get the currently loaded tests for use with DumpCommand preloaded data.
+        /// </summary>
+        public Lazy<SingleTest>[]? LoadedFiles => myInputFiles;
+
+        private EtwSession()
+        {
+            ColorConsole.EnableColor = false; // Disable color output for MCP server context to render faster
+        }
+
+        /// <summary>
+        /// Load one or multiple input files. Mirrors ConsoleCommand.Load().
+        /// </summary>
+        /// <param name="filePaths">File or directory paths to load.</param>
+        /// <param name="keepOldFiles">If true, add to existing loaded files.</param>
+        /// <param name="recursive">If true, search directories recursively.</param>
+        /// <returns>Summary of loaded files.</returns>
+        public string Load(string[] filePaths, bool keepOldFiles, bool recursive)
+        {
+            List<Lazy<SingleTest>> tests = new();
+            List<string> messages = new();
+
+            foreach (var arg in filePaths)
+            {
+                if (string.IsNullOrEmpty(arg))
+                {
+                    continue;
+                }
+
+                messages.Add($"Loading {arg}");
+                try
+                {
+                    var runs = TestRun.CreateFromDirectory(arg, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly, null);
+                    IEnumerable<SingleTest> filesToAdd = runs.SelectMany(x => x.Tests).SelectMany(x => x.Value);
+
+                    HashSet<string> extractedUniqueFiles = filesToAdd.SelectMany(x => x.Files).Select(x => x.JsonExtractFileWhenPresent).Where(x => x != null).ToHashSet();
+                    var jsonTests = extractedUniqueFiles.Select(jsonFileName =>
+                    {
+                        var test = new SingleTest(new TestDataFile[] { new TestDataFile(jsonFileName) });
+                        test.KeepExtract = true;
+                        return new Lazy<SingleTest>(() => test);
+                    });
+
+                    tests.AddRange(jsonTests);
+                }
+                catch (Exception ex)
+                {
+                    messages.Add($"Error: Could not load file {arg}. Got {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            myInputFiles = (keepOldFiles && myInputFiles != null) ? myInputFiles.Concat(tests).ToArray() : tests.ToArray();
+
+            if (myInputFiles != null)
+            {
+                foreach (var test in myInputFiles)
+                {
+                    foreach (var file in test.Value.Files)
+                    {
+                        messages.Add(file.FileName);
+                    }
+                }
+                messages.Add($"Loaded {myInputFiles.Length} files.");
+            }
+
+            return string.Join(Environment.NewLine, messages);
+        }
+
+        /// <summary>
+        /// Unload files. Mirrors ConsoleCommand.Unload().
+        /// </summary>
+        /// <param name="filesToUnload">Specific files to unload, or empty to unload all.</param>
+        /// <returns>Summary message.</returns>
+        public string Unload(string[] filesToUnload)
+        {
+            if (filesToUnload == null || filesToUnload.Length == 0)
+            {
+                int count = myInputFiles?.Length ?? 0;
+                myInputFiles = [];
+                return $"Unloaded all {count} files.";
+            }
+            else
+            {
+                List<string> toUnload = filesToUnload.Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+                if (myInputFiles != null)
+                {
+                    int before = myInputFiles.Length;
+                    myInputFiles = myInputFiles.Select(x =>
+                    {
+                        var inputFiles = x.Value.Files.Where(f => !toUnload.Contains(f.FileName) && f.JsonExtractFileWhenPresent != null).ToArray();
+                        var filteredJsonFiles = inputFiles.Select(f => new TestDataFile(f.JsonExtractFileWhenPresent)).ToArray();
+                        return filteredJsonFiles.Length > 0 ? new Lazy<SingleTest>(() =>
+                        {
+                            var test = new SingleTest(filteredJsonFiles)
+                            {
+                                KeepExtract = true
+                            };
+                            return test;
+                        }) : null;
+                    }).Where(x => x != null).Cast<Lazy<SingleTest>>().ToArray();
+
+                    return $"Unloaded {before - myInputFiles.Length} files. {myInputFiles.Length} files remaining.";
+                }
+
+                return "No files were loaded.";
+            }
+        }
+
+        /// <summary>
+        /// List currently loaded files. Mirrors ConsoleCommand.ListFiles().
+        /// </summary>
+        /// <returns>File listing or message indicating no files loaded.</returns>
+        public string ListFiles()
+        {
+            if (myInputFiles == null || myInputFiles.Length == 0)
+            {
+                return "No files are loaded.";
+            }
+
+            var files = myInputFiles.SelectMany(x => x.Value.Files).Select(x => x.FileName).ToList();
+            files.Add($"Total: {myInputFiles.Length} files loaded.");
+            return string.Join(Environment.NewLine, files);
+        }
+
+        /// <summary>
+        /// Apply -fd filter to the loaded files, same pattern as ConsoleCommand.ApplyFileDirFilter().
+        /// </summary>
+        /// <param name="args">Command arguments that may contain -fd filter.</param>
+        /// <returns>Filtered args (without -fd) and filtered files.</returns>
+        public (string[] FilteredArgs, Lazy<SingleTest>[] FilteredFiles) ApplyFileDirFilter(string[] args)
+        {
+            List<Lazy<SingleTest>> filteredFiles = new(myInputFiles ?? Enumerable.Empty<Lazy<SingleTest>>());
+            List<string> filteredArgs = new();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string lower = args[i].ToLowerInvariant();
+                switch (lower)
+                {
+                    case "-fd":
+                    case "-filedir":
+                        if (i + 1 < args.Length)
+                        {
+                            string filter = args[i + 1];
+                            var match = Matcher.CreateMatcher(filter);
+                            filteredFiles = filteredFiles.Where(x => match(x.Value.Files[0].FileName)).ToList();
+                        }
+                        i++;
+                        break;
+                    default:
+                        filteredArgs.Add(args[i]);
+                        break;
+                }
+            }
+
+            return (filteredArgs.ToArray(), filteredFiles.ToArray());
+        }
+    }
+}

--- a/ETWAnalyzer.McpServer/Program.cs
+++ b/ETWAnalyzer.McpServer/Program.cs
@@ -1,0 +1,15 @@
+//// SPDX-FileCopyrightText:  © 2026 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.McpServer.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddMcpServer()
+    .WithStdioServerTransport()
+    .WithTools<EtwAnalyzerTools>();
+
+var app = builder.Build();
+await app.RunAsync();

--- a/ETWAnalyzer.McpServer/README.md
+++ b/ETWAnalyzer.McpServer/README.md
@@ -1,0 +1,116 @@
+# ETWAnalyzer MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes ETWAnalyzer's ETW trace analysis capabilities as tools for AI assistants.
+
+## Overview
+
+This server allows any MCP-compatible AI client (Claude Desktop, GitHub Copilot, etc.) to query ETW trace data by calling tools that map to ETWAnalyzer's dump commands. The server operates **in-process** by directly referencing the ETWAnalyzer library, using the same internal command pattern as the interactive console mode (`-console`).
+
+### Performance
+
+Files are loaded once via `etw_load` and remain in memory for all subsequent queries. This avoids re-reading and decompressing Json7z files on every command—the same optimization used in ETWAnalyzer's console mode.
+
+## Prerequisites
+
+- .NET 10 Runtime (Windows x64)
+- Extracted Json7z files (use ETWAnalyzer `-extract` to produce them from ETL files)
+
+## Configuration
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "etwanalyzer": {
+      "command": "C:\\path\\to\\ETWAnalyzer.McpServer.exe",
+    }
+  }
+}
+```
+
+### Visual Studio / GitHub Copilot
+
+Add to your `.vscode/mcp.json` or Visual Studio MCP configuration:
+
+```json
+{
+  "servers": {
+    "etwanalyzer": {
+      "type": "stdio",
+      "command": "C:\\path\\to\\ETWAnalyzer.McpServer.exe",
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `etw_load` | Load Json7z/Json files into the session (kept in memory) |
+| `etw_unload` | Unload files from the session |
+| `etw_list` | List currently loaded files |
+| `etw_dump_cpu` | Dump CPU consumption data (sampling/context switch) |
+| `etw_dump_process` | Dump process information (name, PID, command line, times) |
+| `etw_dump_exception` | Dump .NET exceptions with types, messages, counts |
+| `etw_dump_memory` | Dump memory usage (Working Set, Committed Memory) |
+| `etw_dump_disk` | Dump Disk I/O data |
+| `etw_dump_file` | Dump File I/O data |
+| `etw_dump_dns` | Dump DNS query latency data |
+| `etw_dump_tcp` | Dump TCP connection data |
+| `etw_dump_marker` | Dump ETW marker events |
+| `etw_dump_threadpool` | Dump .NET ThreadPool starvation events |
+| `etw_dump_power` | Dump Windows Power Profile settings |
+| `etw_dump_stats` | Dump ETW trace statistics |
+| `etw_dump_version` | Dump module/DLL version information |
+| `etw_dump_objectref` | Dump kernel object handle events |
+| `etw_dump_virtualalloc` | Dump VirtualAlloc memory allocation events |
+| `etw_dump_lbr` | Dump Last Branch Record profiling data |
+| `etw_dump_pmc` | Dump Performance Monitor Counter data |
+| `etw_help` | Get help for ETWAnalyzer dump commands |
+
+## Workflow
+
+1. **Load** extracted Json7z files into the session:
+   ```
+   etw_load(filePaths: "C:\\traces\\Extract\\mytrace.json7z")
+   ```
+   Or load an entire directory:
+   ```
+   etw_load(filePaths: "C:\\traces\\Extract", recursive: true)
+   ```
+
+2. **Query** the loaded data using dump tools (files stay in memory):
+   ```
+   etw_dump_cpu(arguments: "-Methods *Initialize* -topN 5 -ProcessName myapp.exe")
+   ```
+
+3. **Investigate** specific issues:
+   ```
+   etw_dump_exception(arguments: "-Type *TimeoutException* -ShowStack")
+   ```
+
+4. **Filter** loaded files with `-fd` in any dump command:
+   ```
+   etw_dump_cpu(arguments: "-fd *testcase1* -Methods *Render*")
+   ```
+
+5. **Unload** when done:
+   ```
+   etw_unload()
+   ```
+
+## Building
+
+```bash
+dotnet build ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csproj
+```
+
+## Running Standalone
+
+```bash
+dotnet run --project ETWAnalyzer.McpServer
+```
+
+The server will start and listen on stdin/stdout for MCP protocol messages.

--- a/ETWAnalyzer.McpServer/Tools/EtwAnalyzerTools.cs
+++ b/ETWAnalyzer.McpServer/Tools/EtwAnalyzerTools.cs
@@ -1,0 +1,309 @@
+//// SPDX-FileCopyrightText:  © 2026 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.Commands;
+using ETWAnalyzer.EventDump;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace ETWAnalyzer.McpServer.Tools
+{
+    /// <summary>
+    /// MCP tools that operate on loaded ETW data in-process using the same pattern as ConsoleCommand.
+    /// Files are loaded once via etw_load and reused across all dump commands.
+    /// </summary>
+    [McpServerToolType]
+    public sealed class EtwAnalyzerTools
+    {
+        [McpServerTool(Name = "etw_load")]
+        [Description("Load one or more Json7z/Json extracted ETW files or directories into the session. " +
+                     "Files remain loaded for all subsequent dump commands. Use 'keepOldFiles=true' to add to existing loaded files.")]
+        public static string Load(
+            [Description("Comma-separated file paths or directory paths to load (e.g. 'C:\\Extract\\test.json7z' or 'C:\\Extract')")] string filePaths,
+            [Description("If true, add to existing loaded files instead of replacing them. Default: false")] bool keepOldFiles = false,
+            [Description("If true, search directories recursively. Default: false")] bool recursive = false)
+        {
+            string[] paths = filePaths.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            return EtwSession.Instance.Load(paths, keepOldFiles, recursive);
+        }
+
+        [McpServerTool(Name = "etw_unload")]
+        [Description("Unload files from the session. If no files are specified, all files are unloaded.")]
+        public static string Unload(
+            [Description("Optional: Comma-separated file paths to unload. If empty, all files are unloaded.")] string filePaths = "")
+        {
+            string[] paths = string.IsNullOrWhiteSpace(filePaths)
+                ? Array.Empty<string>()
+                : filePaths.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            return EtwSession.Instance.Unload(paths);
+        }
+
+        [McpServerTool(Name = "etw_list")]
+        [Description("List all currently loaded ETW files in the session.")]
+        public static string ListFiles()
+        {
+            return EtwSession.Instance.ListFiles();
+        }
+
+        [McpServerTool(Name = "etw_dump_cpu")]
+        [Description("Dump CPU consumption data (sampling and context switch) from loaded files. " +
+                     "Shows method inclusive CPU time, wait time, and ready time per process. " +
+                     "Use -Methods to filter specific methods, -topN to limit processes, -topNMethods to limit methods.")]
+        public static string DumpCpu(
+            [Description("Arguments for the CPU dump command (e.g. '-Methods *Initialize* -topN 5 -ProcessName myapp.exe')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.CPU, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_process")]
+        [Description("Dump process information (name, pid, command line, start/stop time, return code, parent) from loaded files. " +
+                     "Use -SortBy Tree to show process tree, -Crash to show crashed processes.")]
+        public static string DumpProcess(
+            [Description("Arguments for the Process dump command (e.g. '-ProcessName cmd.exe -SortBy Tree')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Process, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_exception")]
+        [Description("Dump managed exceptions from loaded files. Shows exception type, message, count per process. " +
+                     "Use -Type to filter by exception type, -ShowStack to see stack traces.")]
+        public static string DumpException(
+            [Description("Arguments for the Exception dump command (e.g. '-Type *TimeoutException* -ShowStack')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Exception, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_memory")]
+        [Description("Dump memory usage (working set, committed memory) per process from loaded files. " +
+                     "Use -SortBy Commit/WorkingSet/Diff to control sorting, -TopN to limit output.")]
+        public static string DumpMemory(
+            [Description("Arguments for the Memory dump command (e.g. '-TopN 10 -SortBy Commit')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Memory, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_disk")]
+        [Description("Dump Disk IO data per directory/file/process from loaded files. " +
+                     "Use -DirLevel to control directory depth, -PerProcess to see per-process breakdown.")]
+        public static string DumpDisk(
+            [Description("Arguments for the Disk dump command (e.g. '-DirLevel 3 -PerProcess')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Disk, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_file")]
+        [Description("Dump File IO data showing read/write sizes, times, and counts from loaded files. " +
+                     "Use -PerProcess for per-process view, -FileOperation to filter by operation type.")]
+        public static string DumpFile(
+            [Description("Arguments for the File dump command (e.g. '-PerProcess -fileName E:\\Store*')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.File, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_dns")]
+        [Description("Dump DNS query latency and results from loaded files. " +
+                     "Shows query names, durations, and optional adapter/IP information.")]
+        public static string DumpDns(
+            [Description("Arguments for the DNS dump command (e.g. '-DnsQueryFilter *google* -MinMaxTime 20ms')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Dns, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_tcp")]
+        [Description("Dump TCP connection data including sent/received bytes, retransmissions from loaded files.")]
+        public static string DumpTcp(
+            [Description("Arguments for the TCP dump command (e.g. '-SortBy RetransmissionCount -MinMaxRetransCount 1')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.TCP, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_marker")]
+        [Description("Dump ETW marker events from loaded files. Useful for correlating custom events with trace timelines.")]
+        public static string DumpMarker(
+            [Description("Arguments for the Marker dump command (e.g. '-MarkerFilter *Start* -ZeroTime marker *_Start')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Mark, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_threadpool")]
+        [Description("Dump .NET ThreadPool starvation events from loaded files.")]
+        public static string DumpThreadPool(
+            [Description("Arguments for the ThreadPool dump command")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.ThreadPool, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_power")]
+        [Description("Dump Windows Power Profile settings from loaded files. Use -Diff to compare two files.")]
+        public static string DumpPower(
+            [Description("Arguments for the Power dump command (e.g. '-details' or '-Diff')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Power, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_stats")]
+        [Description("Dump ETW trace statistics (OS version, trace time range, event counts) from loaded files.")]
+        public static string DumpStats(
+            [Description("Arguments for the Stats dump command (e.g. '-Properties *')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Stats, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_version")]
+        [Description("Dump module/dll version information from loaded files. Use -dll to filter specific modules.")]
+        public static string DumpVersion(
+            [Description("Arguments for the Version dump command (e.g. '-dll mylib.dll')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.Version, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_objectref")]
+        [Description("Dump Handle/Object reference tracking data (Create/Close/Leak) from loaded files.")]
+        public static string DumpObjectRef(
+            [Description("Arguments for the ObjectRef dump command (e.g. '-Leak -ShowStack')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.ObjectRef, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_virtualalloc")]
+        [Description("Dump VirtualAlloc memory allocation events from loaded files. Shows committed/freed memory per process.")]
+        public static string DumpVirtualAlloc(
+            [Description("Arguments for the VirtualAlloc dump command (e.g. '-Details -ShowStack -TopNStacks 10')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.VirtualAlloc, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_lbr")]
+        [Description("Dump Last Branch Record (LBR) CPU profiling data from loaded files.")]
+        public static string DumpLbr(
+            [Description("Arguments for the LBR dump command (e.g. '-pn myapp -topnmethods 6 -showcaller')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.LBR, arguments);
+        }
+
+        [McpServerTool(Name = "etw_dump_pmc")]
+        [Description("Dump Performance Monitor Counter (PMC) data from loaded files.")]
+        public static string DumpPmc(
+            [Description("Arguments for the PMC dump command (e.g. '-pn sorter')")] string arguments = "")
+        {
+            return ExecuteDumpCommand(DumpCommands.PMC, arguments);
+        }
+
+        [McpServerTool(Name = "etw_help")]
+        [Description("Get help for ETWAnalyzer dump commands. Shows available options and their descriptions.")]
+        public static string Help(
+            [Description("Specific dump command to get help for (e.g. 'CPU', 'Process', 'Memory'). Leave empty for general help.")] string command = "")
+        {
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                return DumpCommand.HelpString;
+            }
+
+            string[] args = new[] { "-dump", command, "-help" };
+            try
+            {
+                var cmd = new DumpCommand(args);
+                cmd.Parse();
+            }
+            catch (InvalidOperationException ex) when (ex.Message == "-help")
+            {
+                return $"See ETWAnalyzer documentation for -dump {command} options.";
+            }
+            catch (Exception ex)
+            {
+                return $"Help for '{command}': {ex.Message}";
+            }
+
+            return DumpCommand.HelpString;
+        }
+
+        /// <summary>
+        /// Core execution method that creates a DumpCommand with preloaded data and captures its output.
+        /// Mirrors the pattern in ConsoleCommand.CreateDumpCommand().
+        /// </summary>
+        private static string ExecuteDumpCommand(DumpCommands dumpType, string arguments)
+        {
+            var session = EtwSession.Instance;
+            if (session.LoadedFiles == null || session.LoadedFiles.Length == 0)
+            {
+                return "Error: No files are loaded. Use etw_load to load files first.";
+            }
+
+            // Parse arguments respecting quoted strings
+            string[] rawArgs = SplitArguments(arguments);
+
+            // Apply -fd filter to narrow loaded files
+            var (filteredArgs, filteredFiles) = session.ApplyFileDirFilter(rawArgs);
+
+            // Build final args: -dump <type> <filteredArgs>
+            string dumpTypeStr = GetParseString(dumpType);
+            string[] cmdArgs = new[] { "-dump", dumpTypeStr }.Concat(filteredArgs).ToArray();
+
+            using var capture = new ConsoleOutputCapture();
+            try
+            {
+                var dumpCommand = new DumpCommand(cmdArgs, filteredFiles);
+                dumpCommand.Parse();
+                dumpCommand.Run();
+            }
+            catch (Exception ex)
+            {
+                string output = capture.GetOutput();
+                return string.IsNullOrEmpty(output)
+                    ? $"Error executing dump {dumpType}: {ex.Message}"
+                    : output + Environment.NewLine + $"Error: {ex.Message}";
+            }
+
+            return capture.GetOutput();
+        }
+
+        /// <summary>
+        /// Maps <see cref="DumpCommands"/> enum values to the lowercase parse token expected by <see cref="DumpCommand.Parse"/>.
+        /// </summary>
+        private static string GetParseString(DumpCommands command) => command.ToString().ToLowerInvariant();
+
+        /// <summary>
+        /// Split arguments string respecting quoted substrings.
+        /// </summary>
+        private static string[] SplitArguments(string arguments)
+        {
+            if (string.IsNullOrWhiteSpace(arguments))
+            {
+                return Array.Empty<string>();
+            }
+
+            var parts = new System.Collections.Generic.List<string>();
+            var current = new System.Text.StringBuilder();
+            bool inQuotes = false;
+
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                char c = arguments[i];
+                if (c == '"')
+                {
+                    inQuotes = !inQuotes;
+                    continue;
+                }
+
+                if (c == ' ' && !inQuotes)
+                {
+                    if (current.Length > 0)
+                    {
+                        parts.Add(current.ToString());
+                        current.Clear();
+                    }
+                    continue;
+                }
+
+                current.Append(c);
+            }
+
+            if (current.Length > 0)
+            {
+                parts.Add(current.ToString());
+            }
+
+            return parts.ToArray();
+        }
+    }
+}

--- a/ETWAnalyzer.Reader/AssemblyInfo.cs
+++ b/ETWAnalyzer.Reader/AssemblyInfo.cs
@@ -14,5 +14,6 @@ using System.Runtime.Versioning;
 [assembly: InternalsVisibleTo("ETWAnalyzer")]
 [assembly: InternalsVisibleTo("ETWAnalyzer_uTest")]
 [assembly: InternalsVisibleTo("ETWAnalyzer_iTest")]
+[assembly: InternalsVisibleTo("ETWAnalyzer.McpServer")]
 [assembly: InternalsVisibleTo("ProfilingDataManager")]
                                            

--- a/ETWAnalyzer.Reader/ETWAnalyzer.Reader.csproj
+++ b/ETWAnalyzer.Reader/ETWAnalyzer.Reader.csproj
@@ -15,39 +15,32 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Siemens-Healthineers/ETWAnalyzer</PackageProjectUrl>
     <PackageReadmeFile>ProgramaticAccess.md</PackageReadmeFile>
-    <Version>4.5.0.0</Version>
+    <Version>4.5.0.1</Version>
     <FileVersion>1.0.0.0</FileVersion>
     <NoWarn>NU5100;NU1904</NoWarn>
     <EmbedAllSources>true</EmbedAllSources>
     <BaseOutputPath>..\bin</BaseOutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
     <DebugType>embedded</DebugType>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>..\bin\Release\</OutputPath>
     <DebugType>embedded</DebugType>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
     <DebugType>full</DebugType>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>..\bin\Debug\</OutputPath>
     <DebugType>full</DebugType>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
@@ -87,7 +80,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.2.24"/>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0"/>

--- a/ETWAnalyzer.Reader/Extract/Modules/IModuleContainer.cs
+++ b/ETWAnalyzer.Reader/Extract/Modules/IModuleContainer.cs
@@ -21,6 +21,11 @@ namespace ETWAnalyzer.Extract.Modules
         IReadOnlyList<IPdbIdentifier> UnresolvedPdbs { get; }
 
         /// <summary>
+        /// Count of all Pdbs which should be loaded. The not loaded ones are in <seealso cref="UnresolvedPdbs"/>. 
+        /// </summary>
+        public int TotalPdbCount { get; }
+
+        /// <summary>
         /// Find Module Definition for a loaded module in a process.
         /// </summary>
         /// <param name="moduleName">Module name</param>

--- a/ETWAnalyzer.Reader/Extract/Modules/ModuleContainer.cs
+++ b/ETWAnalyzer.Reader/Extract/Modules/ModuleContainer.cs
@@ -40,6 +40,11 @@ namespace ETWAnalyzer.Extract.Modules
         IReadOnlyList<IPdbIdentifier> IModuleContainer.UnresolvedPdbs { get => UnresolvedPdbs; }
 
         /// <summary>
+        /// Count of all Pdbs which should be loaded. The not loaded ones are in UnresolvedPdbs. 
+        /// </summary>
+        public int TotalPdbCount { get; set; }
+
+        /// <summary>
         /// Common strings like file names, directories, file descriptions ... go here into this global list so we can reference in other instances the strings by index 
         /// to save space in the generate json file. This sacrifices readability for a smaller Json file.
         /// </summary>

--- a/ETWAnalyzer.sln
+++ b/ETWAnalyzer.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
@@ -29,6 +30,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETWAnalyzer.Reader", "ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj", "{D4BAB343-CDFA-4069-B395-6086037B6BE5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETWAnalyzer.Reader.Example", "Samples\ETWAnalyzer.Reader.Example\ETWAnalyzer.Reader.Example.csproj", "{26A538E3-492C-1D2C-55E2-FF59ECD23E97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ETWAnalyzer.McpServer", "ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csproj", "{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -124,6 +127,18 @@ Global
 		{26A538E3-492C-1D2C-55E2-FF59ECD23E97}.Release|x64.Build.0 = Release|Any CPU
 		{26A538E3-492C-1D2C-55E2-FF59ECD23E97}.Release|x86.ActiveCfg = Release|Any CPU
 		{26A538E3-492C-1D2C-55E2-FF59ECD23E97}.Release|x86.Build.0 = Release|Any CPU
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|Any CPU.Build.0 = Debug|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|x64.ActiveCfg = Debug|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|x64.Build.0 = Debug|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|Any CPU.ActiveCfg = Release|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|Any CPU.Build.0 = Release|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|x64.ActiveCfg = Release|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|x64.Build.0 = Release|x64
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1FF7C5D-EAF1-4E1C-A1E6-A11924964F4B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ETWAnalyzer/Commands/DumpCommand.cs
+++ b/ETWAnalyzer/Commands/DumpCommand.cs
@@ -1933,7 +1933,7 @@ namespace ETWAnalyzer.Commands
                         myCommand = DumpCommands.CPU;
                         break;
                     case "exception":
-                        myCommand = DumpCommands.Exceptions;
+                        myCommand = DumpCommands.Exception;
                         break;
                     case "stats":
                         myCommand = DumpCommands.Stats;
@@ -1942,7 +1942,7 @@ namespace ETWAnalyzer.Commands
                         myCommand = DumpCommands.Process;
                         break;
                     case "version":
-                        myCommand = DumpCommands.Versions;
+                        myCommand = DumpCommands.Version;
                         break;
                     case "memory":
                         myCommand = DumpCommands.Memory;
@@ -1957,7 +1957,7 @@ namespace ETWAnalyzer.Commands
                         myCommand = DumpCommands.Power;
                         break;
                     case "testrun":
-                        myCommand = DumpCommands.TestRuns;
+                        myCommand = DumpCommands.TestRun;
                         break;
                     case "threadpool":
                         myCommand = DumpCommands.ThreadPool;
@@ -2125,7 +2125,7 @@ namespace ETWAnalyzer.Commands
                     case DumpCommands.Power:
                         lret = PowerExamples + Environment.NewLine + PowerHelpString;
                         break;
-                    case DumpCommands.Exceptions:
+                    case DumpCommands.Exception:
                         lret = ExceptionExamples + Environment.NewLine + ExceptionHelpString;
                         break;
                     case DumpCommands.Memory:
@@ -2137,10 +2137,10 @@ namespace ETWAnalyzer.Commands
                     case DumpCommands.Stats:
                         lret = StatsExamples + Environment.NewLine + StatsHelpString;
                         break;
-                    case DumpCommands.TestRuns:
+                    case DumpCommands.TestRun:
                         lret = TestRunExamples + Environment.NewLine + TestRunHelpString;
                         break;
-                    case DumpCommands.Versions:
+                    case DumpCommands.Version:
                         lret = VersionExamples + Environment.NewLine + VersionHelpString;
                         break;
                     case DumpCommands.ThreadPool:
@@ -2182,7 +2182,7 @@ namespace ETWAnalyzer.Commands
         public override void Run()
         {
             string decompressedETL = null;
-            if (myCommand < DumpCommands.TestRuns && myCommand != DumpCommands.None)
+            if (myCommand < DumpCommands.TestRun && myCommand != DumpCommands.None)
             {
                 string ext = Path.GetExtension(myEtlFileOrZip);
                 if (ext == TestRun.ExtractExtension)
@@ -2229,7 +2229,7 @@ namespace ETWAnalyzer.Commands
                             OneLine = OneLine,
                         };
                         break;
-                    case DumpCommands.Versions:
+                    case DumpCommands.Version:
                         ThrowIfFileOrDirectoryIsInvalid(FileOrDirectoryQueries);
                         myCurrentDumper = new DumpModuleVersions()
                         {
@@ -2492,7 +2492,7 @@ namespace ETWAnalyzer.Commands
                             ShowDiff = ShowDiff,
                         };
                         break;
-                    case DumpCommands.Exceptions:
+                    case DumpCommands.Exception:
                         ThrowIfFileOrDirectoryIsInvalid(FileOrDirectoryQueries);
                         myCurrentDumper = new DumpExceptions
                         {
@@ -2639,7 +2639,7 @@ namespace ETWAnalyzer.Commands
                         };
                         break;
 
-                    case DumpCommands.TestRuns:
+                    case DumpCommands.TestRun:
                         ThrowIfFileOrDirectoryIsInvalid(FileOrDirectoryQueries);
                         myCurrentDumper = new TestRunDumper
                         {
@@ -2984,7 +2984,7 @@ namespace ETWAnalyzer.Commands
                 DumpCommands.Disk => DumpDisk.ValidSortOrders,
                 DumpCommands.File => DumpFile.ValidSortOrders,
                 DumpCommands.Memory => DumpMemory.ValidSortOrders,
-                DumpCommands.Exceptions => DumpExceptions.ValidSortOrders,
+                DumpCommands.Exception => DumpExceptions.ValidSortOrders,
                 DumpCommands.Dns => DumpDns.ValidSortOrders,
                 DumpCommands.TCP => context switch
                 {

--- a/ETWAnalyzer/Commands/DumpCommand.cs
+++ b/ETWAnalyzer/Commands/DumpCommand.cs
@@ -51,7 +51,7 @@ namespace ETWAnalyzer.Commands
         "            -dll xx.dll              All file versions of that dll are printed. If -dll * is used all file versions are printed." + Environment.NewLine +
         "            -topn dd [nn]             Valid when -dll ... is used. Limit output to last dd processes where optionally nn are skipped from alphabetically sorted list." + Environment.NewLine + 
         "            -ShowTotal None           When None omit per process summary of loaded vs visible modules. When Total do not print all matching modules to console. " + Environment.NewLine +  
-        "            -MissingPdb filter        Print a filtered summary of all unresolved pdbs which could not be resolved during extraction and would lead to unresolved methods in CPU Sampling/CSwitch data." + Environment.NewLine +
+        "            -MissingPdb [filter]      Print a filtered summary of all unresolved pdbs which could not be resolved during extraction and would lead to unresolved methods in CPU Sampling/CSwitch data. Filter is optional and defaults to * which matches all missing pdbs." + Environment.NewLine +
         "            -VersionFilter filter     Filter against module path and version strings. Multiple filters are separated by ;. Wildcards are * and ?. Exclusion filters start with !" + Environment.NewLine +
         "            -ModuleFilter  filter     Extracted data from Config\\DllToBuildMapping.json. Print only version information for module. Multiple filters are separated by ;. Wildcards are * and ?. Exclusion filters start with !" + Environment.NewLine;
         static readonly string ProcessHelpStringHeader =
@@ -1490,7 +1490,7 @@ namespace ETWAnalyzer.Commands
                         ProviderFilter = new KeyValuePair<string, Func<string, bool>>(providerFilter, Matcher.CreateMatcher(providerFilter));
                         break;
                     case "-missingpdb":
-                        string pdbFilter = GetNextNonArg("-missingpdb");
+                        string pdbFilter = GetNextNonArg("-missingpdb", false) ?? "*"; // filter is optional. Default to * which matches all missing pdbs.
                         MissingPdbFilter = new KeyValuePair<string, Func<string, bool>>(pdbFilter, Matcher.CreateMatcher(pdbFilter));
                         ModulePrintMode = DumpModuleVersions.PrintMode.Pdb;
                         break;

--- a/ETWAnalyzer/ETWAnalyzer.csproj
+++ b/ETWAnalyzer/ETWAnalyzer.csproj
@@ -3,21 +3,17 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <TargetFrameworks>net10.0-windows</TargetFrameworks>
     <RootNamespace>ETWAnalyzer</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
-    <PackageCopyToOutput>true</PackageCopyToOutput>
-    <DocumentationFile>..\bin\$(Configuration)\ETWAnalyzer.xml</DocumentationFile>
     <NoWarn>NU5100;NU1904;CS0618</NoWarn>
     <EmbedAllSources>true</EmbedAllSources>
-
-    <Platforms>x64</Platforms>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+	<Platforms>x64</Platforms>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -48,22 +44,6 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net4.7.2|AnyCPU'">
-    <DocumentationFile>..\bin\Debug\ETWAnalyzer.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net4.7.2|x64'">
-    <DocumentationFile>..\bin\Debug\ETWAnalyzer.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net4.7.2|AnyCPU'">
-    <DocumentationFile>..\bin\Release\ETWAnalyzer.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net4.7.2|x64'">
-    <DocumentationFile>..\bin\Release\ETWAnalyzer.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -80,14 +60,6 @@
     </PackageReference>
     <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.2.24" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig">

--- a/ETWAnalyzer/EventDump/DumpCommands.cs
+++ b/ETWAnalyzer/EventDump/DumpCommands.cs
@@ -29,7 +29,7 @@ namespace ETWAnalyzer.EventDump
         /// <summary>
         /// Dump TestRuns from a specific directory
         /// </summary>
-        TestRuns = 500,
+        TestRun = 500,
 
         /// <summary>
         /// Print all events by count
@@ -39,7 +39,7 @@ namespace ETWAnalyzer.EventDump
         /// <summary>
         /// Dump Module version of use ETL file
         /// </summary>
-        Versions,
+        Version,
 
         /// <summary>
         /// Dump costs of methods of all files in a directory or an extracted json file
@@ -49,7 +49,7 @@ namespace ETWAnalyzer.EventDump
         /// <summary>
         /// Dump Exceptions
         /// </summary>
-        Exceptions,
+        Exception,
 
         /// <summary>
         /// Dump Memory statistics

--- a/ETWAnalyzer/EventDump/DumpModuleVersions.cs
+++ b/ETWAnalyzer/EventDump/DumpModuleVersions.cs
@@ -232,9 +232,12 @@ namespace ETWAnalyzer.EventDump
 
             if (!IsCSVEnabled)
             {
-                foreach (var missing in added.OrderBy(x=>x.MissingPdb.Name))
+                if (ShowTotal != TotalModes.Total)
                 {
-                    ColorConsole.WriteEmbeddedColorLine($"  Missing Pdb {missing.MissingPdb.Name} {missing.MissingPdb.Age} {missing.MissingPdb.Id}");
+                    foreach (var missing in added.OrderBy(x => x.MissingPdb.Name))
+                    {
+                        ColorConsole.WriteEmbeddedColorLine($"  Missing Pdb {missing.MissingPdb.Name} {missing.MissingPdb.Age} {missing.MissingPdb.Id}");
+                    }
                 }
                 ColorConsole.WriteEmbeddedColorLine($"[red]Total {data.Modules.UnresolvedPdbs.Count}/{data.Modules.TotalPdbCount} pdbs missing, {added.Count} missing pdbs have CPU Samples and match the pdb name filter.[/red]");
             }

--- a/ETWAnalyzer/EventDump/DumpModuleVersions.cs
+++ b/ETWAnalyzer/EventDump/DumpModuleVersions.cs
@@ -236,7 +236,7 @@ namespace ETWAnalyzer.EventDump
                 {
                     ColorConsole.WriteEmbeddedColorLine($"  Missing Pdb {missing.MissingPdb.Name} {missing.MissingPdb.Age} {missing.MissingPdb.Id}");
                 }
-                ColorConsole.WriteEmbeddedColorLine($"[red]Total {data.Modules.UnresolvedPdbs.Count}/{data.Modules.TotalPdbCount} pdbs missing, {added.Count} pdbs have CPU Samples and match the pdb name filter.[/red]");
+                ColorConsole.WriteEmbeddedColorLine($"[red]Total {data.Modules.UnresolvedPdbs.Count}/{data.Modules.TotalPdbCount} pdbs missing, {added.Count} missing pdbs have CPU Samples and match the pdb name filter.[/red]");
             }
 
             lret.AddRange(added);

--- a/ETWAnalyzer/EventDump/DumpModuleVersions.cs
+++ b/ETWAnalyzer/EventDump/DumpModuleVersions.cs
@@ -236,7 +236,7 @@ namespace ETWAnalyzer.EventDump
                 {
                     ColorConsole.WriteEmbeddedColorLine($"  Missing Pdb {missing.MissingPdb.Name} {missing.MissingPdb.Age} {missing.MissingPdb.Id}");
                 }
-                ColorConsole.WriteEmbeddedColorLine($"[red]Total {data.Modules.UnresolvedPdbs.Count} pdbs missing, {added.Count} are matching filter[/red]");
+                ColorConsole.WriteEmbeddedColorLine($"[red]Total {data.Modules.UnresolvedPdbs.Count}/{data.Modules.TotalPdbCount} pdbs missing, {added.Count} pdbs have CPU Samples and match the pdb name filter.[/red]");
             }
 
             lret.AddRange(added);

--- a/ETWAnalyzer/Extractors/ExtractSingleFile.cs
+++ b/ETWAnalyzer/Extractors/ExtractSingleFile.cs
@@ -293,6 +293,7 @@ namespace ETWAnalyzer.Extractors
             {
                 // The sort uses the default comparer which uses the IComparable interface implementation of PdbIdentifier
                 myResults.Modules.UnresolvedPdbs.Sort();
+                myResults.Modules.TotalPdbCount = myPendingSymbols.Result.Pdbs.Count;
             }
 
             

--- a/ETWAnalyzer/MakeRelease.cmd
+++ b/ETWAnalyzer/MakeRelease.cmd
@@ -22,6 +22,13 @@ dotnet build !ScriptLocation!\..\ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csp
 dotnet publish !ScriptLocation!\..\ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csproj /p:Configuration=Release -f !ScriptTargetFW! -r !ScriptRID! /p:SelfContained=true /p:PublishReadyToRun=true /p:PublishSingleFile=false /p:PublishDir=!BinMCPServerNet10!
 dotnet publish !ScriptLocation!\ETWAnalyzer.csproj /p:Configuration=Release -f !ScriptTargetFW! -r !ScriptRID! /p:SelfContained=true /p:PublishReadyToRun=true /p:PublishSingleFile=false /p:PublishDir=!BinFolderNet10!
 
+REM Make the bundled ETWAnalyzer.exe runnable inside the MCP server folder.
+REM Publishing McpServer copies ETWAnalyzer.dll/.exe but NOT ETWAnalyzer.deps.json
+REM (only the entry project gets a .deps.json), so its apphost cannot start.
+REM The standalone ETWAnalyzer publish above produces a matching .deps.json
+REM (same TFM/RID/Config); copy it next to the bundled apphost so both exes run.
+copy /Y "!BinFolderNet10!\ETWAnalyzer.deps.json" "!BinMCPServerNet10!\ETWAnalyzer.deps.json"
+
 dotnet build !ScriptLocation!\..\ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj  /p:Configuration=Release -f net48
 dotnet pack  !ScriptLocation!\..\ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj  /p:Configuration=Release 
 

--- a/ETWAnalyzer/MakeRelease.cmd
+++ b/ETWAnalyzer/MakeRelease.cmd
@@ -4,30 +4,31 @@ echo Build Targets
 setlocal enabledelayedexpansion
 set ScriptLocation=%~d0%~p0
 set BinFolderNet10=!ScriptLocation!..\bin\Release\net10.0-windows\win-x64
+set BinMCPServerNet10=!ScriptLocation!..\bin\Release\publishMCPNet10
 set BinSamplesFolder=!ScriptLocation!..\Samples\bin\x64\Release
+set BinNotSelfContained=!ScriptLocation!..\bin\Release\Net10-NotSelfContained
 
 set ObjFolder=!ScriptLocation!\obj
+set ObjFolderMCPServer=!ScriptLocation!\..\ETWAnalyzer.McpServer\obj
+set ObjFolderReader=!ScriptLocation!\..\ETWAnalyzer.Reader\obj
 
-set ReleaseZipNet10=!ScriptLocation!\..\bin\Release\ETWAnalyzer_Net10.zip
-set ReleaseSamples=!ScriptLocation!..\bin\Release\Samples_Binaries.zip
+set ScriptPublishProfile=!ScriptLocation!\Properties\PublishProfiles\Net10_SelfContained.pubxml
+set ScriptTargetFW=net10.0-windows
+set ScriptRID=win-x64
 
-del !ReleaseZipNet10! 2> NUL
-del !ReleaseSamples! 2> NUL
+call :CleanTempFiles
 
-rd /q /s !BinFolderNet10!
-rd /q /s !BinSamplesFolder!
-rd /q /s !ObjFolder!
+dotnet build !ScriptLocation!\..\ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csproj /p:Configuration=Release -o !BinNotSelfContained!
+dotnet publish !ScriptLocation!\..\ETWAnalyzer.McpServer\ETWAnalyzer.McpServer.csproj /p:Configuration=Release -f !ScriptTargetFW! -r !ScriptRID! /p:SelfContained=true /p:PublishReadyToRun=true /p:PublishSingleFile=false /p:PublishDir=!BinMCPServerNet10!
+dotnet publish !ScriptLocation!\ETWAnalyzer.csproj /p:Configuration=Release -f !ScriptTargetFW! -r !ScriptRID! /p:SelfContained=true /p:PublishReadyToRun=true /p:PublishSingleFile=false /p:PublishDir=!BinFolderNet10!
 
-dotnet publish !ScriptLocation!\ETWAnalyzer.csproj /p:PublishProfile=!ScriptLocation!\ETWAnalyzer\Properties\PublishProfiles\Net10_SelfContained.pubxml /p:Configuration=Release /p:TargetFramework=net10.0-windows /p:PublishDir=!BinFolderNet10!
 dotnet build !ScriptLocation!\..\ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj  /p:Configuration=Release -f net48
 dotnet pack  !ScriptLocation!\..\ETWAnalyzer.Reader\ETWAnalyzer.Reader.csproj  /p:Configuration=Release 
 
-msbuild /p:Configuration=Release /p:Platform=x64 /p:OutDir=!BinSamplesFolder! !ScriptLocation!\..\Samples\EventLeak\EventLeak.vcxproj 
+msbuild /p:Configuration=Release /p:Platform=x64 /p:OutDir=!BinSamplesFolder!\ !ScriptLocation!\..\Samples\EventLeak\EventLeak.vcxproj 
 
 call :DelFile "!BinFolderNet10!"
-
-7z a  !ReleaseZipNet10! -r "!BinFolderNet10!\*.*"
-7z a  !ReleaseSamples! -r "!BinSamplesFolder!\*.*"
+call :DelFile "!BinMCPServerNet10!"
 
 goto :EOF
 
@@ -38,4 +39,16 @@ echo Delete superflous files
 del ETWAnalyzer_Trace.log 2> NUL
 rd /q /s x86
 rd /q /s arm64
+exit /B 1
+
+:CleanTempFiles
+
+rd /q /s !BinFolderNet10! 2> NUL
+rd /q /s !BinSamplesFolder! 2> NUL
+rd /q /s !ObjFolder! 2> NUL
+rd /q /s !ObjFolderMCPServer! 2> NUL
+rd /q /s !ObjFolderReader! 2> NUL
+rd /q /s !BinMCPServerNet10! 2> NUL
+rd /q /s !BinNotSelfContained! 2> NUL
+
 exit /B 1

--- a/ETWAnalyzer/Properties/AssemblyInfo.cs
+++ b/ETWAnalyzer/Properties/AssemblyInfo.cs
@@ -34,6 +34,7 @@ using System.Runtime.Versioning;
 [assembly: InternalsVisibleTo("ETWAnalyzer_uTest")]
 [assembly: InternalsVisibleTo("ETWAnalyzer_iTest")]
 [assembly: InternalsVisibleTo("LogTester")]
+[assembly: InternalsVisibleTo("ETWAnalyzer.McpServer")]
 [assembly: InternalsVisibleTo("ProfilingDataManager")]
 
 // Version information for an assembly consists of the following four values:
@@ -47,4 +48,4 @@ using System.Runtime.Versioning;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.0.0")]
+[assembly: AssemblyFileVersion("4.5.0.1")]

--- a/ETWAnalyzer_uTest/Commands/DumpCommandMissingPdbTests.cs
+++ b/ETWAnalyzer_uTest/Commands/DumpCommandMissingPdbTests.cs
@@ -1,0 +1,57 @@
+//// SPDX-FileCopyrightText:  © 2025 Siemens Healthcare GmbH
+//// SPDX-License-Identifier:   MIT
+
+using ETWAnalyzer.Commands;
+using Xunit;
+
+namespace ETWAnalyzer_uTest.Commands
+{
+    /// <summary>
+    /// Verifies command line parsing of the optional -MissingPdb filter argument of the Dump Version command.
+    /// </summary>
+    public class DumpCommandMissingPdbTests
+    {
+        /// <summary>
+        /// When -MissingPdb is specified without a following filter the filter defaults to *
+        /// which matches all missing pdbs.
+        /// </summary>
+        [Fact]
+        public void MissingPdb_Without_Filter_Defaults_To_Star()
+        {
+            DumpCommand cmd = new DumpCommand(new string[] { "Version", "-missingpdb" });
+            cmd.Parse();
+
+            Assert.Equal("*", cmd.MissingPdbFilter.Key);
+            // Default * filter must match any pdb name.
+            Assert.True(cmd.MissingPdbFilter.Value("ntdll.pdb"));
+        }
+
+        /// <summary>
+        /// When -MissingPdb is followed by a filter the filter string is used as is.
+        /// </summary>
+        [Fact]
+        public void MissingPdb_With_Filter_Uses_Specified_Filter()
+        {
+            DumpCommand cmd = new DumpCommand(new string[] { "Version", "-missingpdb", "ntdll*" });
+            cmd.Parse();
+
+            Assert.Equal("ntdll*", cmd.MissingPdbFilter.Key);
+            Assert.True(cmd.MissingPdbFilter.Value("ntdll.pdb"));
+            Assert.False(cmd.MissingPdbFilter.Value("kernel32.pdb"));
+        }
+
+        /// <summary>
+        /// When -MissingPdb is followed by another switch argument the filter defaults to *
+        /// and the following switch is still parsed.
+        /// </summary>
+        [Fact]
+        public void MissingPdb_Followed_By_Switch_Defaults_To_Star()
+        {
+            DumpCommand cmd = new DumpCommand(new string[] { "Version", "-missingpdb", "-clip" });
+            cmd.Parse();
+
+            Assert.Equal("*", cmd.MissingPdbFilter.Key);
+            Assert.True(cmd.MissingPdbFilter.Value("anything.pdb"));
+        }
+    }
+}


### PR DESCRIPTION
- Implement a stdio MCP server to give AI access to extracted Json7z files.
- First tests did show that AI is surprisingly good to find root causes from ETWAnalyzer summary files. This makes it possible to feed AI not the large multi GB ETL files but the small Json7z files which can be queried by ETWAnalyzer commands. The filter capabilities of ETWAnalyzer makes the output managable for AI given its limited context window. 
- Improved -dump version -missingpdb command which now shows a more descriptive messages and correlates it with the total pdb count which is now since this version also extracted. 